### PR TITLE
Syntax highlights python block in readme.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,9 @@ To install Rubicon, use pip::
 
     $ pip install rubicon-objc
 
-Then, in a Python shell::
+Then, in a Python shell
+
+.. code-block:: python
 
     >>> from ctypes import cdll
     >>> from ctypes import util


### PR DESCRIPTION
This highlights the syntax block in README.rst. It changes from

```
end of sentence here.::

    >>> import antigravity
```

to 

``` 
end of sentence here.

.. code-block:: python
    >>> import antigravity
```