### PR TITLE
Add UI/NSEdgeInsets/EdgeInsetsMake structs and functions.

### DIFF
--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -13,7 +13,7 @@ from .types import (
     text,
     NSInteger, NSUInteger,
     CGFloat,
-    NSPointEncoding, NSSizeEncoding, NSRectEncoding, NSRangeEncoding,
+    NSPointEncoding, NSSizeEncoding, NSRectEncoding, NSRangeEncoding, UIEdgeInsetsEncoding, NSEdgeInsetsEncoding,
     CGPoint, NSPoint,
     CGSize, NSSize,
     CGRect, NSRect,
@@ -23,5 +23,7 @@ from .types import (
     NSTimeInterval,
     CFIndex, UniChar, unichar, CGGlyph,
     CFRange, NSRange,
-    NSZeroPoint
+    NSZeroPoint,
+    UIEdgeInsets, UIEdgeInsetsMake, UIEdgeInsetsZero,
+    NSEdgeInsets, NSEdgeInsetsMake
 )

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -682,6 +682,8 @@ class ObjCMethod(object):
         NSSizeEncoding: NSSize,
         NSRectEncoding: NSRect,
         NSRangeEncoding: NSRange,
+        UIEdgeInsetsEncoding: UIEdgeInsets,
+        NSEdgeInsetsEncoding: NSEdgeInsets,
         PyObjectEncoding: py_object
     }
 

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -36,6 +36,8 @@ if __LP64__:
     NSSizeEncoding = b'{CGSize=dd}'
     NSRectEncoding = b'{CGRect={CGPoint=dd}{CGSize=dd}}'
     NSRangeEncoding = b'{_NSRange=QQ}'
+    UIEdgeInsetsEncoding = b'{UIEdgeInsets=dddd}'
+    NSEdgeInsetsEncoding = b'{NSEdgeInsets=dddd}'
 else:
     NSInteger = c_int
     NSUInteger = c_uint
@@ -44,6 +46,8 @@ else:
     NSSizeEncoding = b'{CGSize=ff}'
     NSRectEncoding = b'{CGRect={CGPoint=ff}{CGSize=ff}}'
     NSRangeEncoding = b'{NSRange=II}'
+    UIEdgeInsetsEncoding = b'{UIEdgeInsets=ffff}'
+    NSEdgeInsetsEncoding = b'{NSEdgeInsets=ffff}'
 
 NSIntegerEncoding = encoding_for_ctype(NSInteger)
 NSUIntegerEncoding = encoding_for_ctype(NSUInteger)
@@ -96,6 +100,33 @@ def NSMakePoint(x, y):
     return NSPoint(x, y)
 
 CGPointMake = NSMakePoint
+
+
+# iOS: /System/Library/Frameworks/UIKit.framework/Headers/UIGeometry.h
+class UIEdgeInsets(Structure):
+    _fields_ = [('top', CGFloat),
+                ('left', CGFloat),
+                ('bottom', CGFloat),
+                ('right', CGFloat)]
+
+def UIEdgeInsetsMake(top, left, bottom, right):
+    return UIEdgeInsets(top, left, bottom, right)
+
+UIEdgeInsetsZero = UIEdgeInsets(0, 0, 0, 0)
+
+
+# macOS: /System/Library/Frameworks/AppKit.framework/Headers/NSLayoutConstraint.h
+class NSEdgeInsets(Structure):
+    _fields_ = [('top', CGFloat),
+                ('left', CGFloat),
+                ('bottom', CGFloat),
+                ('right', CGFloat)]
+
+def NSEdgeInsetsMake(top, left, bottom, right):
+    return NSEdgeInsets(top, left, bottom, right)
+
+# strangely, there is no NSEdgeInsetsZero, neither in public nor in private API.
+
 
 # NSDate.h
 NSTimeInterval = c_double

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -11,7 +11,7 @@ try:
 except:
     OSX_VERSION = None
 
-from rubicon.objc import ObjCClass, objc_method, objc_classmethod, objc_property
+from rubicon.objc import ObjCClass, objc_method, objc_classmethod, objc_property, NSEdgeInsets, NSEdgeInsetsMake
 
 
 # Load the test harness library
@@ -412,4 +412,19 @@ class RubiconTest(unittest.TestCase):
         # Assign None to dealloc property and see if method returns expected None
         box.url = None
         self.assertIsNone(box.getSchemeIfPresent())
+
+    def test_function_NSEdgeInsetsMake(self):
+        "Python can invoke NSEdgeInsetsMake to create NSEdgeInsets."
+
+        insets = NSEdgeInsets(0.0, 1.1, 2.2, 3.3)
+        other_insets = NSEdgeInsetsMake(0.0, 1.1, 2.2, 3.3)
+
+        # structs are NOT equal
+        self.assertNotEqual(insets, other_insets)
+
+        # but their values are
+        self.assertEqual(insets.top, other_insets.top)
+        self.assertEqual(insets.left, other_insets.left)
+        self.assertEqual(insets.bottom, other_insets.bottom)
+        self.assertEqual(insets.right, other_insets.right)
 


### PR DESCRIPTION
Adds UIEdgeInsets and NSEdgeInsets structs, helper functions UIEdgeInsetsMake and NSEdgeInsetsMake and global UIEdgeInsetsZero instance.

References:
https://developer.apple.com/reference/uikit/uiedgeinsets?language=objc
https://developer.apple.com/reference/foundation/nsedgeinsets?language=objc

Declarations found in:
- iOS: /System/Library/Frameworks/UIKit.framework/Headers/UIGeometry.h
- macOS: /System/Library/Frameworks/AppKit.framework/Headers/NSLayoutConstraint.h