### PR TITLE
Fixes for send_message on non-x86_64 architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,10 @@ local
 *.o
 *.d
 *.dylib
+
+# OS X
+.DS_Store
+
+# PyCharm
+.idea/
+*.iml

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
-
 OBJ_FILES=tests/objc/Thing.o tests/objc/Example.o tests/objc/BaseExample.o
+
+# By default, build a universal i386/x86_64 binary.
+# Modify here (or on the command line) to build for other architecture(s).
+EXTRA_FLAGS=-arch i386 -arch x86_64
 
 all: tests/objc/librubiconharness.dylib
 
 tests/objc/librubiconharness.dylib: $(OBJ_FILES)
-	clang -dynamiclib $(OBJ_FILES) -fobjc-arc -fobjc-link-runtime -o tests/objc/librubiconharness.dylib
+	clang -dynamiclib -fobjc-link-runtime $(EXTRA_FLAGS) $(OBJ_FILES) -o tests/objc/librubiconharness.dylib
 
 clean:
 	rm -rf tests/objc/*.o tests/objc/*.d tests/objc/librubiconharness.dylib
 
-%.o : %.m
-	clang -x objective-c -fobjc-arc -I./tests/objc -c $< -o $@
+%.o: %.m
+	clang -x objective-c -fobjc-arc -I./tests/objc -c $(EXTRA_FLAGS) $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,5 @@ clean:
 	rm -rf tests/objc/*.o tests/objc/*.d tests/objc/librubiconharness.dylib
 
 %.o: %.m
-	clang -x objective-c -fobjc-arc -I./tests/objc -c $(EXTRA_FLAGS) $< -o $@
+	clang -x objective-c -I./tests/objc -c $(EXTRA_FLAGS) $< -o $@
 

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -470,9 +470,9 @@ def send_message(receiver, selName, *args, **kwargs):
         result = send(receiver, selector, *args)
     elif should_use_stret(restype):
         send = objc['objc_msgSend_stret']
-        send.argtypes = [POINTER(restype), c_void_p, c_void_p] + argtypes
-        result = restype()
-        send(byref(result), receiver, selector, *args)
+        send.restype = restype
+        send.argtypes = [c_void_p, c_void_p] + argtypes
+        result = send(receiver, selector, *args)
     else:
         send = objc['objc_msgSend']
         send.restype = restype

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -4,13 +4,19 @@ import platform
 import struct
 
 __LP64__ = (8*struct.calcsize("P") == 64)
-__i386__ = (platform.machine() == 'i386')
-__x86_64__ = (platform.machine() == 'x86_64')
+
+# platform.machine() indicates the machine's physical architecture,
+# which means that on a 64-bit Intel machine it is always "x86_64",
+# even if Python is built as 32-bit.
+_any_x86 = (platform.machine() in ('i386', 'x86_64'))
+__i386__ = (_any_x86 and not __LP64__)
+__x86_64__ = (_any_x86 and __LP64__)
 
 # On iOS, platform.machine() is a device identifier like "iPhone9,4",
-# but the platform.version() string contains the architecture. 
-__arm64__ = ('ARM64' in platform.version())
-__arm__ = (not __arm64__ and 'ARM' in platform.version())
+# but the platform.version() string contains the architecture.
+_any_arm = ('ARM' in platform.version())
+__arm64__ = (_any_arm and __LP64__)
+__arm__ = (_any_arm and not __LP64__)
 
 PyObjectEncoding = b'{PyObject=@}'
 

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -56,7 +56,7 @@ else:
     NSPointEncoding = b'{CGPoint=ff}'
     NSSizeEncoding = b'{CGSize=ff}'
     NSRectEncoding = b'{CGRect={CGPoint=ff}{CGSize=ff}}'
-    NSRangeEncoding = b'{NSRange=II}'
+    NSRangeEncoding = b'{_NSRange=II}'
     UIEdgeInsetsEncoding = b'{UIEdgeInsets=ffff}'
     NSEdgeInsetsEncoding = b'{NSEdgeInsets=ffff}'
 

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -7,6 +7,11 @@ __LP64__ = (8*struct.calcsize("P") == 64)
 __i386__ = (platform.machine() == 'i386')
 __x86_64__ = (platform.machine() == 'x86_64')
 
+# On iOS, platform.machine() is a device identifier like "iPhone9,4",
+# but the platform.version() string contains the architecture. 
+__arm__ = ('ARM32' in platform.version())
+__arm64__ = ('ARM64' in platform.version())
+
 PyObjectEncoding = b'{PyObject=@}'
 
 

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -9,8 +9,8 @@ __x86_64__ = (platform.machine() == 'x86_64')
 
 # On iOS, platform.machine() is a device identifier like "iPhone9,4",
 # but the platform.version() string contains the architecture. 
-__arm__ = ('ARM32' in platform.version())
 __arm64__ = ('ARM64' in platform.version())
+__arm__ = (not __arm64__ and 'ARM' in platform.version())
 
 PyObjectEncoding = b'{PyObject=@}'
 

--- a/tests/objc/BaseExample.h
+++ b/tests/objc/BaseExample.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 
-@interface BaseExample : NSObject
+@interface BaseExample : NSObject {
+    int _baseIntField;
+}
 
 @property int baseIntField;
 

--- a/tests/objc/BaseExample.m
+++ b/tests/objc/BaseExample.m
@@ -1,6 +1,8 @@
 #import "BaseExample.h"
 
-@implementation BaseExample;
+@implementation BaseExample
+
+@synthesize baseIntField = _baseIntField;
 
 static int _staticBaseIntField = 1;
 

--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -4,7 +4,11 @@
 #import "Thing.h"
 #import "Callback.h"
 
-@interface Example : BaseExample
+@interface Example : BaseExample {
+    int _intField;
+    Thing *_thing;
+    id<Callback> _callback;
+}
 
 @property int intField;
 @property (retain) Thing *thing;

--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -4,6 +4,21 @@
 #import "Thing.h"
 #import "Callback.h"
 
+/* objc_msgSend on i386, x86_64, ARM64; objc_msgSend_stret on ARM32. */
+struct int_sized {
+    char data[4];
+};
+
+/* objc_msgSend on x86_64, ARM64; objc_msgSend_stret on i386, ARM32. */
+struct oddly_sized {
+    char data[5];
+};
+
+/* objc_msgSend on ARM64; objc_msgSend_stret on i386, x86_64, ARM32. */
+struct large {
+    char data[17];
+};
+
 @interface Example : BaseExample {
     int _intField;
     Thing *_thing;
@@ -42,6 +57,10 @@
 -(float) areaOfSquare: (float) size;
 -(double) areaOfCircle: (double) diameter;
 -(NSDecimalNumber *) areaOfTriangleWithWidth: (NSDecimalNumber *) width andHeight: (NSDecimalNumber *) height;
+
+-(struct int_sized) intSizedStruct;
+-(struct oddly_sized) oddlySizedStruct;
+-(struct large) largeStruct;
 
 -(void) testPoke:(int) value;
 -(void) testPeek:(int) value;

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -132,12 +132,12 @@ static int _staticIntField = 11;
 /* String argument/return value handling */
 -(NSString *) toString
 {
-    return [[NSString alloc] initWithFormat:@"This is an ObjC Example object"];
+    return [NSString stringWithFormat:@"This is an ObjC Example object"];
 }
 
 -(NSString *) duplicateString:(NSString *) in
 {
-    return [[NSString alloc] initWithFormat:@"%@%@", in, in];
+    return [NSString stringWithFormat:@"%@%@", in, in];
 }
 
 -(NSString *) smiley

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -1,7 +1,11 @@
 #import "Example.h"
 #import <stdio.h>
 
-@implementation Example;
+@implementation Example
+
+@synthesize intField = _intField;
+@synthesize thing = _thing;
+@synthesize callback = _callback;
 
 static int _staticIntField = 11;
 

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -101,6 +101,22 @@ static int _staticIntField = 11;
     return [width decimalNumberByMultiplyingBy:[height decimalNumberByDividingBy:[NSDecimalNumber decimalNumberWithString:@"2.0"]]];
 }
 
+/* Handling of struct returns of different sizes. */
+-(struct int_sized) intSizedStruct {
+    struct int_sized ret = {"abc"};
+    return ret;
+}
+
+-(struct oddly_sized) oddlySizedStruct {
+    struct oddly_sized ret = {"abcd"};
+    return ret;
+}
+
+-(struct large) largeStruct {
+    struct large ret = {"abcdefghijklmnop"};
+    return ret;
+}
+
 
 /* Handling of object references. */
 -(void) mutateThing: (Thing *) thing

--- a/tests/objc/Thing.h
+++ b/tests/objc/Thing.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 
-@interface Thing : NSObject
+@interface Thing : NSObject {
+    NSString *_name;
+}
 
 @property (retain) NSString *name;
 

--- a/tests/objc/Thing.m
+++ b/tests/objc/Thing.m
@@ -1,6 +1,8 @@
 #import "Thing.h"
 
-@implementation Thing;
+@implementation Thing
+
+@synthesize name = _name;
 
 -(id) initWithName: (NSString *) name
 {

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -290,6 +290,34 @@ class RubiconTest(unittest.TestCase):
         result = example.areaOfTriangleWithWidth_andHeight_(Decimal('3.0'), Decimal('4.0'))
         self.assertEqual(result, Decimal('6.0'))
         self.assertTrue(isinstance(result, Decimal), 'Result should be a Decimal')
+    
+    def test_struct_return(self):
+        "Methods returning structs of different sizes by value can be handled."
+        Example = ObjCClass('Example')
+        example = Example.alloc().init()
+        
+        class struct_int_sized(Structure):
+            _fields_ = [("x", c_char * 4)]
+
+        example.intSizedStruct
+        example.objc_class.instance_methods["intSizedStruct"].restype = struct_int_sized
+        self.assertEqual(example.intSizedStruct().x, b"abc")
+        
+        class struct_oddly_sized(Structure):
+            _fields_ = [("x", c_char * 5)]
+        
+        example.oddlySizedStruct
+        example.objc_class.instance_methods["oddlySizedStruct"].restype = struct_oddly_sized
+        self.assertEqual(example.oddlySizedStruct().x, b"abcd")
+        
+        class struct_large(Structure):
+            _fields_ = [("x", c_char * 17)]
+        
+        example.largeStruct
+        example.objc_class.instance_methods["largeStruct"].restype = struct_large
+        self.assertEqual(example.largeStruct().x, b"abcdefghijklmnop")
+        
+        # TODO other structs
 
     def test_object_return(self):
         "If a method or field returns an object, you get an instance of that type returned"

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -20,6 +20,13 @@ if harnesslib is None:
     raise RuntimeError("Couldn't load Rubicon test harness library. Have you set DYLD_LIBRARY_PATH?")
 cdll.LoadLibrary(harnesslib)
 
+import sys
+import platform
+print("sys.platform = " + repr(sys.platform))
+print("platform.machine() = " + repr(platform.machine()))
+print("platform.version() = " + repr(platform.version()))
+print("sys.maxsize = " + hex(sys.maxsize))
+
 
 class RubiconTest(unittest.TestCase):
     def test_field(self):

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,17 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py34, py35, pypy3
+envlist = {py34,py35,pypy3}-{default,i386}
 
 [testenv]
-commands = {envpython} setup.py test
+basepython = 
+    py34: python3.4
+    py35: python3.5
+    pypy3: pypy3
+
+commands =
+    default: {envpython} setup.py test
+    i386: arch -i386 -e DYLD_LIBRARY_PATH="{env:DYLD_LIBRARY_PATH}" {envpython} setup.py test
+
 setenv =
     DYLD_LIBRARY_PATH = {toxinidir}/tests/objc
-deps =


### PR DESCRIPTION
My original goal was to fix structure returns on 32-bit iOS (ARM32), but then I went down a bit of a rabbit hole. I apologize for the large PR - there were some tests/fixes for one arch that uncovered more issues on another arch, and I didn't want to PR half-broken code.

Short summary of the changes:

* Architecture detection for ARM32 and ARM64 (`__arm__` and `__arm64__` bools to match `__i386__` and `__x86_64__`)
* Fixes for `objc_msgSend`/`objc_msgSend_stret` selection on i386, ARM32 and ARM64
* Unit tests for struct-returning methods
* Unit tests for `send_message` (which is not used often, and had some bugs on non-x86_64 architectures because of that)
* Universal build (i386 and x86_64) for the test harness library
* Test environments to test the library in i386 mode on 64-bit OS X
* Some minor fixes

For more details on how and why all of this happened, see the commit log, I explained the reasons for most of the fixes there.

The unit tests all run fine for me on Python 3.4 and 3.5 on i386 and x86_64, and I did some manual testing on ARM32 and ARM64 on iOS as well. But if I broke something else by accident, please tell me.