### PR TITLE
Allow disabling argument and result conversion when calling ObjCMethods

### DIFF
--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -381,6 +381,9 @@ class RubiconTest(unittest.TestCase):
 
         the_thing = example.thing
         self.assertEqual(the_thing.toString(), "This is thing 2")
+    
+    def test_cfstring_to_str(self):
+        self.assertEqual(str(core_foundation.at("abcdefg")), "abcdefg")
 
     def test_no_convert_return(self):
         Example = ObjCClass("Example")

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -14,7 +14,7 @@ except:
 import faulthandler
 faulthandler.enable()
 
-from rubicon.objc import ObjCClass, objc_method, objc_classmethod, objc_property, NSEdgeInsets, NSEdgeInsetsMake, send_message
+from rubicon.objc import ObjCClass, ObjCInstance, objc_method, objc_classmethod, objc_property, NSEdgeInsets, NSEdgeInsetsMake, send_message
 from rubicon.objc import core_foundation
 
 
@@ -381,6 +381,14 @@ class RubiconTest(unittest.TestCase):
 
         the_thing = example.thing
         self.assertEqual(the_thing.toString(), "This is thing 2")
+
+    def test_no_convert_return(self):
+        Example = ObjCClass("Example")
+        example = Example.alloc().init()
+        
+        res = example.toString(convert_result=False)
+        self.assertNotIsInstance(res, ObjCInstance)
+        self.assertEqual(str(ObjCInstance(res)), "This is an ObjC Example object")
 
     def test_duplicate_class_registration(self):
         "If you define a class name twice in the same runtime, you get an error."


### PR DESCRIPTION
Suppressing result conversion is useful when you want to call methods on an objects that would be converted to Python objects (such as `NSString`), or when a method returns an `id` that isn't actually valid. Suppressing argument conversion is not as useful, but there are probably use cases for that too, so I added that as well.

I also made a small change to argument conversion, so it only converts arguments to (Core) Foundation types if the respective argtype is `objc_id`. Otherwise a call like `NSString.stringWithUTF8String_(b"foobar")` fails, because the bytestring is converted to `NSString` by `to_value`.

(Also added a test for my previous PR.)