### PR TITLE
Make ObjCClass inherit from ObjCInstance

### DIFF
--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -3,7 +3,7 @@ __version__ = '0.2.3'
 from .objc import (
     objc, send_message, send_super,
     get_selector,
-    ObjCClass, ObjCInstance, NSObject,
+    ObjCInstance, ObjCClass, ObjCMetaClass, NSObject,
     objc_ivar, objc_property, objc_rawmethod, objc_method, objc_classmethod
 )
 

--- a/rubicon/objc/core_foundation.py
+++ b/rubicon/objc/core_foundation.py
@@ -164,7 +164,7 @@ def to_number(cfnumber):
 
     # NSDecimalNumber reports as a double. So does an NSNumber of type double.
     # In the case of NSDecimalNumber, convert to a Python decimal.
-    if numeric_type == kCFNumberDoubleType and cfnumber.__dict__['objc_class'].name == 'NSDecimalNumber':
+    if numeric_type == kCFNumberDoubleType and cfnumber.objc_class.name == 'NSDecimalNumber':
         return Decimal(cfnumber.stringValue)
 
     # Otherwise, just do the conversion.

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -50,7 +50,7 @@ class SEL(c_void_p):
     def __repr__(self):
         return "{cls.__module__}.{cls.__qualname__}({self.name!r})".format(cls=type(self), self=self)
 
-class Class(c_void_p):
+class Class(objc_id):
     pass
 
 class IMP(c_void_p):
@@ -328,6 +328,10 @@ objc.object_copy.argtypes = [objc_id, c_size_t]
 # id object_dispose(id obj)
 objc.object_dispose.restype = objc_id
 objc.object_dispose.argtypes = [objc_id]
+
+# BOOL object_isClass(id obj)
+objc.object_isClass.restype = c_bool
+objc.object_isClass.argtypes = [objc_id]
 
 # Class object_getClass(id object)
 objc.object_getClass.restype = Class
@@ -891,40 +895,23 @@ class ObjCBoundMethod(object):
 ######################################################################
 
 
-def cache_instance_method(self, name):
+def cache_method(cls, name):
     """Returns a python representation of the named instance method,
     either by looking it up in the cached list of methods or by searching
     for and creating a new method object."""
     try:
-        return self.__dict__['instance_methods'][name]
+        return cls.__dict__['instance_methods'][name]
     except KeyError:
         selector = get_selector(name.replace('_', ':'))
-        method = objc.class_getInstanceMethod(self.__dict__['ptr'], selector)
+        method = objc.class_getInstanceMethod(cls, selector)
         if method.value:
             objc_method = ObjCMethod(method)
-            self.__dict__['instance_methods'][name] = objc_method
+            cls.__dict__['instance_methods'][name] = objc_method
             return objc_method
     return None
 
 
-def cache_class_method(self, name):
-    """Returns a python representation of the named class method,
-    either by looking it up in the cached list of methods or by searching
-    for and creating a new method object."""
-    try:
-        return self.__dict__['class_methods'][name]
-    except KeyError:
-        selector = get_selector(name.replace('_', ':'))
-        method = objc.class_getClassMethod(self.__dict__['ptr'], selector)
-
-        if method.value:
-            objc_method = ObjCMethod(method)
-            self.__dict__['class_methods'][name] = objc_method
-            return objc_method
-    return None
-
-
-def cache_instance_property_methods(self, name):
+def cache_property_methods(cls, name):
     """Return the accessor and mutator for the named property.
     """
     if name.endswith('_'):
@@ -934,15 +921,15 @@ def cache_instance_property_methods(self, name):
         methods = None
     else:
         # Check 1: Does the class respond to the property?
-        responds = objc.class_getProperty(self.__dict__['ptr'], name.encode('utf-8'))
+        responds = objc.class_getProperty(cls, name.encode('utf-8'))
 
         # Check 2: Does the class have an instance method to retrieve the given name
         accessor_selector = get_selector(name)
-        accessor = objc.class_getInstanceMethod(self.__dict__['ptr'], accessor_selector)
+        accessor = objc.class_getInstanceMethod(cls, accessor_selector)
 
         # Check 3: Is there a setName: method to set the property with the given name
         mutator_selector = get_selector('set' + name[0].title() + name[1:] + ':')
-        mutator = objc.class_getInstanceMethod(self.__dict__['ptr'], mutator_selector)
+        mutator = objc.class_getInstanceMethod(cls, mutator_selector)
 
         # If the class responds as a property, or it has both an accessor *and*
         # and mutator, then treat it as a property in Python.
@@ -963,93 +950,31 @@ def cache_instance_property_methods(self, name):
     return methods
 
 
-def cache_instance_property_accessor(self, name):
+def cache_property_accessor(cls, name):
     """Returns a python representation of an accessor for the named
     property. Existence of a property is done by looking for the write
     selector (set<Name>:).
     """
     try:
-        methods = self.__dict__['instance_properties'][name]
+        methods = cls.__dict__['instance_properties'][name]
     except KeyError:
-        methods = cache_instance_property_methods(self, name)
-        self.__dict__['instance_properties'][name] = methods
+        methods = cache_property_methods(cls, name)
+        cls.__dict__['instance_properties'][name] = methods
     if methods:
         return methods[0]
     return None
 
 
-def cache_instance_property_mutator(self, name):
+def cache_property_mutator(cls, name):
     """Returns a python representation of an accessor for the named
     property. Existence of a property is done by looking for the write
     selector (set<Name>:).
     """
     try:
-        methods = self.__dict__['instance_properties'][name]
+        methods = cls.__dict__['instance_properties'][name]
     except KeyError:
-        methods = cache_instance_property_methods(self, name)
-        self.__dict__['instance_properties'][name] = methods
-    if methods:
-        return methods[1]
-    return None
-
-
-def cache_class_property_methods(self, name):
-    """Return the accessor and mutator for the named property. Existence
-    of a property is done by looking for the pair of selectors "name" and
-    "set<Name>:". If both exist, we assume this is a static property.
-    """
-    if name.endswith('_'):
-        # If the requested name ends with _, that's a marker that we're
-        # dealing with a method call, not a property, so we can shortcut
-        # the process.
-        methods = None
-    else:
-        accessor_selector = get_selector(name)
-        accessor = objc.class_getClassMethod(self.__dict__['ptr'], accessor_selector)
-        if accessor.value:
-            objc_accessor = ObjCMethod(accessor)
-        else:
-            objc_accessor = None
-
-        mutator_selector = get_selector('set' + name[0].title() + name[1:] + ':')
-        mutator = objc.class_getClassMethod(self.__dict__['ptr'], mutator_selector)
-        if mutator.value:
-            objc_mutator = ObjCMethod(mutator)
-        else:
-            objc_mutator = None
-
-        if objc_accessor and objc_mutator:
-            methods = (objc_accessor, objc_mutator)
-        else:
-            methods = None
-    return methods
-
-
-def cache_class_property_accessor(self, name):
-    """Returns a python representation of an accessor for the named
-    property. Existence of a property is done by looking for the write
-    selector (set<Name>:).
-    """
-    try:
-        methods = self.__dict__['class_properties'][name]
-    except KeyError:
-        methods = cache_class_property_methods(self, name)
-        self.__dict__['class_properties'][name] = methods
-    if methods:
-        return methods[0]
-    return None
-
-
-def cache_class_property_mutator(self, name):
-    """Returns a python representation of an accessor for the named
-    property. Existence of a property is done by looking for the write
-    selector (set<Name>:).
-    """
-    try:
-        methods = self.__dict__['class_properties'][name]
-    except KeyError:
-        methods = cache_class_property_methods(self, name)
-        self.__dict__['class_properties'][name] = methods
+        methods = cache_property_methods(cls, name)
+        cls.__dict__['instance_properties'][name] = methods
     if methods:
         return methods[1]
     return None
@@ -1090,20 +1015,12 @@ def objc_method(f):
         return result
 
     def register(cls):
-        return add_method(cls.__dict__['ptr'], f.__name__.replace('_', ':'), _objc_method, encoding)
+        return add_method(cls, f.__name__.replace('_', ':'), _objc_method, encoding)
 
     _objc_method.register = register
 
     return _objc_method
 
-
-# def objc_classmethod(encoding):
-#     """Function decorator for class methods."""
-#     # Add encodings for hidden self and cmd arguments.
-#     encoding = ensure_bytes(encoding)
-#     typecodes = parse_type_encoding(encoding)
-#     typecodes.insert(1, b'@:')
-#     encoding = b''.join(typecodes)
 
 def objc_classmethod(f):
     encoding = encoding_from_annotation(f)
@@ -1122,7 +1039,7 @@ def objc_classmethod(f):
         return result
 
     def register(cls):
-        return add_method(cls.__dict__['metaclass'], f.__name__.replace('_', ':'), _objc_classmethod, encoding)
+        return add_method(cls.objc_class, f.__name__.replace('_', ':'), _objc_classmethod, encoding)
 
     _objc_classmethod.register = register
 
@@ -1199,17 +1116,6 @@ class objc_property(object):
         cls.__dict__['imp_table'][setter_name] = add_method(cls.__dict__['ptr'], setter_name.replace('_', ':'), _objc_setter, setter_encoding)
 
 
-# def objc_rawmethod(encoding):
-#     """Decorator for instance methods without any fancy shenanigans.
-#     The function must have the signature f(self, cmd, *args)
-#     where both self and cmd are just pointers to objc objects.
-#     """
-#     # Add encodings for hidden self and cmd arguments.
-#     encoding = ensure_bytes(encoding)
-#     typecodes = parse_type_encoding(encoding)
-#     typecodes.insert(1, b'@:')
-#     encoding = b''.join(typecodes)
-
 def objc_rawmethod(f):
     encoding = encoding_from_annotation(f, offset=2)
     name = f.__name__.replace('_', ':')
@@ -1226,7 +1132,11 @@ class ObjCInstance(object):
 
     _cached_objects = {}
 
-    def __new__(cls, object_ptr):
+    @property
+    def objc_class(self):
+        return ObjCClass(objc.object_getClass(self))
+
+    def __new__(cls, object_ptr, _name=None, _bases=None, _ns=None):
         """Create a new ObjCInstance or return a previously created one
         for the given object_ptr which should be an Objective-C id."""
         # Make sure that object_ptr is wrapped in an objc_id.
@@ -1244,31 +1154,40 @@ class ObjCInstance(object):
         # deallocated.
         if object_ptr.value in cls._cached_objects:
             return cls._cached_objects[object_ptr.value]
+        
+        # If the given pointer points to a class, return an ObjCClass instead (if we're not already creating one).
+        if not issubclass(cls, ObjCClass) and objc.object_isClass(object_ptr):
+            return ObjCClass(object_ptr)
 
         # Otherwise, create a new ObjCInstance.
-        objc_instance = super(ObjCInstance, cls).__new__(cls)
-        objc_instance.__dict__['ptr'] = objc_instance.__dict__['_as_parameter_'] = object_ptr
-        # Determine class of this object.
-        class_ptr = objc.object_getClass(object_ptr)
-        objc_instance.__dict__['objc_class'] = ObjCClass(class_ptr)
+        if _name is not None or _bases is not None or _ns is not None:
+            # Special case for ObjCClass to pass on the class name, bases and namespace to the type constructor.
+            self = super().__new__(cls, _name, _bases, _ns)
+        else:
+            self = super().__new__(cls)
+        super(ObjCInstance, type(self)).__setattr__(self, "ptr", object_ptr)
+        super(ObjCInstance, type(self)).__setattr__(self, "_as_parameter_", object_ptr)
 
         # Store new object in the dictionary of cached objects, keyed
         # by the (integer) memory address pointed to by the object_ptr.
-        cls._cached_objects[object_ptr.value] = objc_instance
+        cls._cached_objects[object_ptr.value] = self
 
-        # Create a DeallocationObserver and associate it with this object.
-        # When the Objective-C object is deallocated, the observer will remove
-        # the ObjCInstance corresponding to the object from the cached objects
-        # dictionary, effectively destroying the ObjCInstance.
-        observer = send_message(send_message('DeallocationObserver', 'alloc', restype=objc_id, argtypes=[]), 'initWithObject:', objc_instance, restype=objc_id, argtypes=[objc_id])
-        objc.objc_setAssociatedObject(objc_instance, observer, observer, 0x301)
+        # Classes are never deallocated, so they don't need a DeallocationObserver.
+        # This is also necessary to make the definition of DeallocationObserver work - otherwise creating the ObjCClass for DeallocationObserver would try to instantiate a DeallocationObserver itself.
+        if not objc.object_isClass(object_ptr):
+            # Create a DeallocationObserver and associate it with this object.
+            # When the Objective-C object is deallocated, the observer will remove
+            # the ObjCInstance corresponding to the object from the cached objects
+            # dictionary, effectively destroying the ObjCInstance.
+            observer = send_message(send_message('DeallocationObserver', 'alloc', restype=objc_id, argtypes=[]), 'initWithObject:', self, restype=objc_id, argtypes=[objc_id])
+            objc.objc_setAssociatedObject(self, observer, observer, 0x301)
 
-        # The observer is retained by the object we associate it to.  We release
-        # the observer now so that it will be deallocated when the associated
-        # object is deallocated.
-        send_message(observer, 'release')
+            # The observer is retained by the object we associate it to.  We release
+            # the observer now so that it will be deallocated when the associated
+            # object is deallocated.
+            send_message(observer, 'release')
 
-        return objc_instance
+        return self
     
     def __str__(self):
         from . import core_foundation
@@ -1293,41 +1212,30 @@ class ObjCInstance(object):
         # If the name ends with _, we can shortcut this step, because it's
         # clear that we're dealing with a method call.
         if not name.endswith('_'):
-            method = cache_instance_property_accessor(self.__dict__['objc_class'], name)
+            method = cache_property_accessor(self.objc_class, name)
             if method:
                 return ObjCBoundMethod(method, self)()
 
-        method = cache_instance_method(self.__dict__['objc_class'], name)
+        method = cache_method(self.objc_class, name)
         if method:
             return ObjCBoundMethod(method, self)
         else:
-            try:
-                return self.__dict__[name]
-            except KeyError:
-                # Otherwise, raise an exception.
-                raise AttributeError('ObjCInstance %s has no attribute %s' % (self.__dict__['objc_class'].name, name))
+            raise AttributeError('%s.%s %s has no attribute %s' % (type(self).__module__, type(self).__qualname__, self.objc_class.name, name))
 
     def __setattr__(self, name, value):
         # Convert enums to their underlying values.
         if isinstance(value, Enum):
             value = value.value
         # Set the value of an attribute.
-        method = cache_instance_property_mutator(self.__dict__['objc_class'], name)
+        method = cache_property_mutator(self.objc_class, name)
         if method:
             ObjCBoundMethod(method, self)(value)
         else:
-            self.__dict__[name] = value
+            super(ObjCInstance, type(self)).__setattr__(self, name, value)
 
 
-class ObjCClass(type):
+class ObjCClass(ObjCInstance, type):
     """Python wrapper for an Objective-C class."""
-
-    # We only create one Python object for each Objective-C class.
-    # Any future calls with the same class will return the previously
-    # created Python object.  Note that these aren't weak references.
-    # After you create an ObjCClass, it will exist until the end of the
-    # program.
-    _registered_classes = {}
 
     def __new__(cls, *args):
         """Create a new ObjCClass instance or return a previously created
@@ -1383,75 +1291,34 @@ class ObjCClass(type):
         # Check if we've already created a Python object for this class
         # and if so, return it rather than making a new one.
         try:
-            objc_class = cls._registered_classes[name]
+            self = cls._cached_objects[ptr.value]
         except KeyError:
-
-            # We can get the metaclass only after the class is registered.
-            metaclass = get_metaclass(name)
             objc_class_name = name.decode('utf-8')
 
             # Otherwise create a new Python object and then initialize it.
-            objc_class = super(ObjCClass, cls).__new__(cls, objc_class_name, (ObjCInstance,), {
-                    'ptr': ptr,
-                    'metaclass': metaclass,
+            self = super().__new__(cls, ptr, objc_class_name, (ObjCInstance,), {
                     'name': objc_class_name,
                     'instance_methods': {},     # mapping of name -> instance method
-                    'class_methods': {},        # mapping of name -> class method
                     'instance_properties': {},  # mapping of name -> (accessor method, mutator method)
-                    'class_properties': {},     # mapping of name -> (accessor method, mutator method)
                     'imp_table': {},            # Mapping of name -> Native method references
-                    '_as_parameter_': ptr,      # for ctypes argument passing
                 })
-
-            # Store the new class in dictionary of registered classes.
-            cls._registered_classes[name] = objc_class
 
         # Register all the methods, class methods, etc
         for attr, obj in attrs.items():
             try:
-                objc_class.__dict__['imp_table'][attr] = obj.register(objc_class)
+                self.__dict__['imp_table'][attr] = obj.register(self)
             except AttributeError:
                 # The class attribute doesn't have a register method.
                 pass
             try:
-                obj.register_property(attr, objc_class)
+                obj.register_property(attr, self)
             except AttributeError:
                 pass
 
-        return objc_class
+        return self
 
     def __repr__(self):
         return "<ObjCClass: %s at %#x>" % (self.__dict__['name'], self.__dict__['ptr'].value)
-
-    def __getattr__(self, name):
-        """Returns a callable method object with the given name."""
-        # If name refers to a class method, then return a callable object
-        # for the class method with self.__dict__['ptr'] as hidden first parameter.
-        if not name.endswith('_'):
-            method = cache_class_property_accessor(self, name)
-            if method:
-                return ObjCBoundMethod(method, self.__dict__['ptr'])()
-
-        method = cache_class_method(self, name)
-        if method:
-            return ObjCBoundMethod(method, self.__dict__['ptr'])
-        else:
-            try:
-                return self.__dict__[name]
-            except KeyError:
-                # Otherwise, raise an exception.
-                raise AttributeError('ObjCClass %s has no attribute %s' % (self.name, name))
-
-    def __setattr__(self, name, value):
-        # Convert enums to their underlying values.
-        if isinstance(value, Enum):
-            value = value.value
-        # Set the value of an attribute.
-        method = cache_class_property_mutator(self, name)
-        if method:
-            ObjCBoundMethod(method, self.__dict__['ptr'])(value)
-        else:
-            self.__dict__[name] = value
 
 
 ######################################################################


### PR DESCRIPTION
(I had to swap the order of `ObjCClass` and `ObjCInstance` for this, which makes the default diff somewhat useless. [This diff](https://github.com/dgelessus/rubicon-objc/compare/53b0c4bbc9b110208043a8f714fd115356b55d8b...objcclass_extends_objcinstance) is a bit more useful.)

Objective-C classes are also objects, and class methods are actually instance methods of the corresponding metaclass ([helpful explanation](http://www.sealiesoftware.com/blog/archive/2009/04/14/objc_explain_Classes_and_metaclasses.html), [helpful diagram](http://www.sealiesoftware.com/blog/class%20diagram.pdf)). By making `ObjCClass` inherit from `ObjCInstance`, it is possible to reuse `ObjCInstance`'s code for method and property access in `ObjCClass`. As a side effect, it also means that any methods added to `ObjCInstance` in the future will also work on `ObjCClass`.

To implement this I had to add a small hack to `ObjCInstance.__new__`, which passes on the `name, bases, attrs` arguments to `type` when it gets them from `ObjCClass` via `super`. It's not a major thing though, and it's only needed in a single place - subclasses of `ObjCInstance` are not affected.

Other changes:

* Made `ObjCInstance.objc_class` a property instead of a "real" attribute. I don't remember why exactly this was necessary (I had this branch lying around half-complete for a while), but most likely creating the `objc_class` attribute on instance creation would have resulted in infinite recursion.
* Added an `ObjCMetaClass` class, whose main purpose is to have a different name from `ObjCClass` when looking at the `repr` of a metaclass. Objective-C metaclasses aren't as powerful as Python's, so there's not a lot of other things that can be done with them.
* Made `ObjCInstance` return `ObjCClass`es when receiving a class pointer, and `ObjCClass` return `ObjCMetaClass`es when receiving a metaclass pointer.
* Merged the `ObjCClass` instance cache into the one for `ObjCInstance`s.
* Added unit tests for the behavior of classes and metaclasses (lookup by name or pointer, caching, etc.).