### PR TITLE
Nicer method call syntax using keyword arguments

### DIFF
--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -3,6 +3,7 @@ __version__ = '0.2.3'
 from .objc import (
     objc, send_message, send_super,
     get_selector,
+    SEL, objc_id, Class, IMP, Method, Ivar, objc_property_t,
     ObjCInstance, ObjCClass, ObjCMetaClass, NSObject,
     objc_ivar, objc_property, objc_rawmethod, objc_method, objc_classmethod
 )

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -1251,6 +1251,14 @@ class ObjCInstance(object):
 class ObjCClass(ObjCInstance, type):
     """Python wrapper for an Objective-C class."""
 
+    @property
+    def superclass(self):
+        super_ptr = objc.class_getSuperclass(self)
+        if super_ptr.value is None:
+            return None
+        else:
+            return ObjCClass(super_ptr)
+
     def __new__(cls, *args):
         """Create a new ObjCClass instance or return a previously created
         instance for the given Objective-C class.  The argument may be either

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -33,6 +33,9 @@ class objc_id(c_void_p):
 class SEL(c_void_p):
     @property
     def name(self):
+        if self.value is None:
+            raise ValueError("Cannot get name of null selector")
+        
         return objc.sel_getName(self)
     
     def __new__(cls, init=None):
@@ -50,7 +53,7 @@ class SEL(c_void_p):
             super().__init__(init)
     
     def __repr__(self):
-        return "{cls.__module__}.{cls.__qualname__}({self.name!r})".format(cls=type(self), self=self)
+        return "{cls.__module__}.{cls.__qualname__}({name!r})".format(cls=type(self), name=None if self.value is None else self.name)
 
 class Class(objc_id):
     pass

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -940,6 +940,10 @@ def cache_method(cls, name):
     supercls = cls
     objc_method = None
     while supercls is not None:
+        # Load the class's methods if we haven't done so yet.
+        if supercls.methods_ptr is None:
+            supercls._reload_methods()
+        
         try:
             objc_method = supercls.instance_methods[name]
             break
@@ -1267,6 +1271,10 @@ class ObjCInstance(object):
         # either on self's class or any of the superclasses.
         cls = self.objc_class
         while cls is not None:
+            # Load the class's methods if we haven't done so yet.
+            if cls.methods_ptr is None:
+                cls._reload_methods()
+            
             try:
                 method = cls.partial_methods[name]
                 break
@@ -1417,10 +1425,9 @@ class ObjCClass(ObjCInstance, type):
                     registered_something = True
                     obj.register(self, attr)
             
-            self._reload_methods()
-            
-            # If anything was registered, reload the metaclass's methods, because there may be new class methods.
+            # If anything was registered, reload the methods of this class (and the metaclass, because there may be new class methods).
             if registered_something:
+                self._reload_methods()
                 self.objc_class._reload_methods()
 
         return self

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -765,8 +765,6 @@ class ObjCMethod(object):
         PyObjectEncoding: py_object
     }
 
-    cfunctype_table = {}
-
     def __init__(self, method):
         """Initialize with an Objective-C Method pointer.  We then determine
         the return type and argument type information of the method."""

--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -67,4 +67,8 @@ struct large {
 -(NSString *) getMessage;
 -(NSString *) reverseIt:(NSString *) input;
 
++(NSUInteger) overloaded;
++(NSUInteger) overloaded:(NSUInteger)arg1;
++(NSUInteger) overloaded:(NSUInteger)arg1 extraArg:(NSUInteger)arg2;
+
 @end

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -177,4 +177,19 @@ static int _staticIntField = 11;
     return [self.callback reverse:input];
 }
 
++(NSUInteger) overloaded
+{
+    return 0;
+}
+
++(NSUInteger) overloaded:(NSUInteger)arg1
+{
+    return arg1;
+}
+
++(NSUInteger) overloaded:(NSUInteger)arg1 extraArg:(NSUInteger)arg2
+{
+    return arg1 + arg2;
+}
+
 @end

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -15,7 +15,7 @@ except:
 import faulthandler
 faulthandler.enable()
 
-from rubicon.objc import ObjCInstance, ObjCClass, ObjCMetaClass, NSObject, SEL, objc, objc_method, objc_classmethod, objc_property, NSEdgeInsets, NSEdgeInsetsMake, send_message
+from rubicon.objc import ObjCInstance, ObjCClass, ObjCMetaClass, NSObject, SEL, objc, objc_method, objc_classmethod, objc_property, NSUInteger, NSRange, NSEdgeInsets, NSEdgeInsetsMake, send_message
 from rubicon.objc import core_foundation
 
 
@@ -448,26 +448,28 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass('Example')
         example = Example.alloc().init()
         
+        # FIXME: Overriding the restype like done below is NOT reliable - this code may need to be updated if the method lookup internals change. When #14 is fixed, there should be a better way of setting a custom restype (or it should be set correctly by default).
+        
         class struct_int_sized(Structure):
             _fields_ = [("x", c_char * 4)]
 
-        example.intSizedStruct
-        example.objc_class.instance_methods["intSizedStruct"].restype = struct_int_sized
-        self.assertEqual(example.intSizedStruct().x, b"abc")
+        method = example.intSizedStruct
+        method.method.restype = struct_int_sized
+        self.assertEqual(method().x, b"abc")
         
         class struct_oddly_sized(Structure):
             _fields_ = [("x", c_char * 5)]
         
-        example.oddlySizedStruct
-        example.objc_class.instance_methods["oddlySizedStruct"].restype = struct_oddly_sized
-        self.assertEqual(example.oddlySizedStruct().x, b"abcd")
+        method = example.oddlySizedStruct
+        method.method.restype = struct_oddly_sized
+        self.assertEqual(method().x, b"abcd")
         
         class struct_large(Structure):
             _fields_ = [("x", c_char * 17)]
         
-        example.largeStruct
-        example.objc_class.instance_methods["largeStruct"].restype = struct_large
-        self.assertEqual(example.largeStruct().x, b"abcdefghijklmnop")
+        method = example.largeStruct
+        method.method.restype = struct_large
+        self.assertEqual(method().x, b"abcdefghijklmnop")
 
     def test_struct_return_send(self):
         "Methods returning structs of different sizes by value can be handled when using send_message."
@@ -510,6 +512,36 @@ class RubiconTest(unittest.TestCase):
         res = example.toString(convert_result=False)
         self.assertNotIsInstance(res, ObjCInstance)
         self.assertEqual(str(ObjCInstance(res)), "This is an ObjC Example object")
+    
+    def test_partial_method_no_args(self):
+        Example = ObjCClass("Example")
+        self.assertEqual(Example.overloaded(), 0)
+    
+    def test_partial_method_one_arg(self):
+        Example = ObjCClass("Example")
+        self.assertEqual(Example.overloaded(42), 42)
+    
+    def test_partial_method_two_args(self):
+        Example = ObjCClass("Example")
+        self.assertEqual(Example.overloaded(12, extraArg=34), 12+34)
+
+    def test_partial_method_lots_of_args(self):
+        pystring = "Uñîçö∂€"
+        pybytestring = pystring.encode("utf-8")
+        nsstring = core_foundation.at(pystring)
+        buf = create_string_buffer(len(pybytestring) + 1)
+        usedLength = NSUInteger()
+        remaining = NSRange(0, 0)
+        nsstring.getBytes(
+            buf,
+            maxLength=32,
+            usedLength=byref(usedLength),
+            encoding=4, # NSUTF8StringEncoding
+            options=0,
+            range=NSRange(0, 7),
+            remainingRange=byref(remaining),
+        )
+        self.assertEqual(buf.value.decode("utf-8"), pystring)
 
     def test_duplicate_class_registration(self):
         "If you define a class name twice in the same runtime, you get an error."

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -150,6 +150,22 @@ class RubiconTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             ObjCMetaClass(NSObject.ptr)
     
+    def test_objcclass_superclass(self):
+        Example = ObjCClass("Example")
+        BaseExample = ObjCClass("BaseExample")
+        
+        self.assertEqual(Example.superclass, BaseExample)
+        self.assertEqual(BaseExample.superclass, NSObject)
+        self.assertIsNone(NSObject.superclass)
+    
+    def test_objcmetaclass_superclass(self):
+        Example = ObjCClass("Example")
+        BaseExample = ObjCClass("BaseExample")
+    
+        self.assertEqual(Example.objc_class.superclass, BaseExample.objc_class)
+        self.assertEqual(BaseExample.objc_class.superclass, NSObject.objc_class)
+        self.assertEqual(NSObject.objc_class.superclass, NSObject)
+    
     def test_field(self):
         "A field on an instance can be accessed and mutated"
 

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -15,7 +15,7 @@ except:
 import faulthandler
 faulthandler.enable()
 
-from rubicon.objc import ObjCInstance, ObjCClass, ObjCMetaClass, NSObject, objc, objc_method, objc_classmethod, objc_property, NSEdgeInsets, NSEdgeInsetsMake, send_message
+from rubicon.objc import ObjCInstance, ObjCClass, ObjCMetaClass, NSObject, SEL, objc, objc_method, objc_classmethod, objc_property, NSEdgeInsets, NSEdgeInsetsMake, send_message
 from rubicon.objc import core_foundation
 
 
@@ -34,6 +34,13 @@ print("sys.maxsize = " + hex(sys.maxsize))
 
 
 class RubiconTest(unittest.TestCase):
+    def test_sel_by_name(self):
+        self.assertEqual(SEL(b"foobar").name, b"foobar")
+    
+    def test_sel_null(self):
+        with self.assertRaises(ValueError):
+            SEL(None).name
+    
     def test_class_by_name(self):
         """An Objective-C class can be looked up by name."""
         


### PR DESCRIPTION
Allows calling methods using keyword arguments, like `string.getCharacters(buffer, range=NSRange(0, 5))`. This implements most of #26.

As a side effect, `ObjCClass` now gets the entire array of method pointers on creation, instead of looking them up on demand. (However, `ObjCMethod` objects are *not* created for every method - doing so causes lots of "unknown restype" errors for methods that aren't used.) This appears to have no noticeable effect on performance (the unit tests take roughly 200ms for me before and after the change).

Other changes that were needed to implement this:

* The custom `c_void_p` subclasses (`SEL`, `objc_id`, `Class`, etc.) are now exported in `rubicon.objc`'s `__init__.py`.
* `ObjCClass`es now have a `superclass` attribute.
* `ObjCClass.__setattr__` no longer tries to look for an Objective-C setter if the attribute exists in `__dict__`. This allows setting attributes on an `ObjCClass` without manually accessing the `__dict__`.
* Better handling of null selectors, and simple unit tests for `SEL`. (This is not strictly necessary, but it helped while tracking down a segfault.)
* Minor simplification and clarification of how `register` works when creating new Objective-C subclasses. (This was also a result of me tracking down the segfault.)