### PR TITLE
Add support for registering custom type encodings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+(next version)
+--------------
+
+* Added support for using native Python sequence/mapping syntax with ``NSArray`` and ``NSDictionary``. (jeamland)
+* Added functions for declaring custom conversions between Objective-C type encodings and ``ctypes`` types.
+* Extended the Objective-C type encoding decoder to support block types as well as arbitrary qualifiers and pointers.
+* Changed the ``PyObjectEncoding`` to match the real definition of ``PyObject *``.
+
 0.2.7
 -----
 

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -614,11 +614,11 @@ def add_method(cls, selName, method, encoding):
     The third type code must be a selector.
     Additional type codes are for types of other arguments if any.
     """
-    signature = tuple(type_to_ctype(tp) for tp in encoding)
+    signature = tuple(ctype_for_type(tp) for tp in encoding)
     assert signature[1] == objc_id  # ensure id self typecode
     assert signature[2] == SEL  # ensure SEL cmd typecode
     selector = get_selector(selName)
-    types = b"".join(ctype_to_encoding(ctype) for ctype in signature)
+    types = b"".join(encoding_for_ctype(ctype) for ctype in signature)
 
     cfunctype = CFUNCTYPE(*signature)
     imp = cfunctype(method)
@@ -628,7 +628,7 @@ def add_method(cls, selName, method, encoding):
 
 def add_ivar(cls, name, vartype):
     "Add a new instance variable of type vartype to cls."
-    return objc.class_addIvar(cls, ensure_bytes(name), sizeof(vartype), alignment(vartype), ctype_to_encoding(type_to_ctype(vartype)))
+    return objc.class_addIvar(cls, ensure_bytes(name), sizeof(vartype), alignment(vartype), encoding_for_ctype(ctype_for_type(vartype)))
 
 
 def set_instance_variable(obj, varname, value, vartype):
@@ -667,13 +667,13 @@ class ObjCMethod(object):
             self.argument_types.append(buffer.value)
         # Get types for all the arguments.
         try:
-            self.argtypes = [encoding_to_ctype(t) for t in self.argument_types]
+            self.argtypes = [ctype_for_encoding(t) for t in self.argument_types]
         except ValueError:
             print('No argtypes encoding for %s (%s)' % (self.name, self.argument_types))
             self.argtypes = None
         # Get types for the return type.
         try:
-            self.restype = encoding_to_ctype(self.return_type)
+            self.restype = ctype_for_encoding(self.return_type)
         except ValueError:
             print('No restype encoding for %s (%s)' % (self.name, self.return_type))
             self.restype = None
@@ -1608,8 +1608,8 @@ class ObjCMetaClass(ObjCClass):
 
         return super().__new__(cls, ptr)
 
-register_type_to_ctype(ObjCInstance, objc_id)
-register_type_to_ctype(ObjCClass, Class)
+register_ctype_for_type(ObjCInstance, objc_id)
+register_ctype_for_type(ObjCClass, Class)
 
 
 ######################################################################

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -647,7 +647,9 @@ def cfunctype_for_encoding(encoding):
     return cfunctype
 
 
-def typestring_for_encoding(encoding):
+def encoding_for_ctype(ctype):
+    """Return the Objective-C type encoding for the given ctypes type."""
+    
     typecodes = {
         c_char: b'c',
         c_int: b'i',
@@ -679,7 +681,7 @@ def typestring_for_encoding(encoding):
         NSRange: NSRangeEncoding,
         py_object: PyObjectEncoding,
     }
-    return b''.join(typecodes[e] for e in encoding)
+    return typecodes[ctype]
 
 
 def ctype_for_encoding(encoding):
@@ -754,7 +756,7 @@ def add_method(cls, selName, method, encoding):
     assert(encoding[1] is ObjCInstance)  # ensure id self typecode
     assert(encoding[2] == SEL)  # ensure SEL cmd typecode
     selector = get_selector(selName)
-    types = typestring_for_encoding(encoding)
+    types = b"".join(encoding_for_ctype(ctype) for ctype in encoding)
 
     # Check if we've already created a CFUNCTYPE for this encoding.
     # If so, then return the cached CFUNCTYPE.

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -28,9 +28,13 @@ c = cdll.LoadLibrary(_find_or_error('c'))
 objc = cdll.LoadLibrary(_find_or_error('objc'))
 Foundation = cdll.LoadLibrary(_find_or_error('Foundation'))
 
+@with_preferred_encoding(b'@')
+# @? is the encoding for blocks.
+@with_encoding(b'@?')
 class objc_id(c_void_p):
     pass
 
+@with_preferred_encoding(b':')
 class SEL(c_void_p):
     @property
     def name(self):
@@ -56,6 +60,7 @@ class SEL(c_void_p):
     def __repr__(self):
         return "{cls.__module__}.{cls.__qualname__}({name!r})".format(cls=type(self), name=None if self.value is None else self.name)
 
+@with_preferred_encoding(b'#')
 class Class(objc_id):
     pass
 
@@ -70,12 +75,6 @@ class Ivar(c_void_p):
 
 class objc_property_t(c_void_p):
     pass
-
-register_preferred_encoding(b':', SEL)
-register_preferred_encoding(b'@', objc_id)
-# @? is the encoding for blocks.
-register_encoding(b'@?', objc_id)
-register_preferred_encoding(b'#', Class)
 
 ######################################################################
 

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -442,7 +442,7 @@ def ensure_bytes(x):
     if isinstance(x, bytes):
         return x
     # "All char * in the runtime API should be considered to have UTF-8 encoding."
-    # https://developer.apple.com/reference/objectivec/1657527-objective_c_runtime?language=objc
+    # https://developer.apple.com/documentation/objectivec/objective_c_runtime?preferredLanguage=occ
     return x.encode('utf-8')
 
 

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -597,9 +597,6 @@ def encoding_from_annotation(f, offset=1):
     return encoding
 
 
-cfunctype_table = {}
-
-
 def type_to_ctype(tp):
     """Convert the given type to a ctypes type.
     This translates Python built-in types and rubicon.objc classes to their ctypes equivalents.
@@ -724,13 +721,7 @@ def add_method(cls, selName, method, encoding):
     selector = get_selector(selName)
     types = b"".join(encoding_for_ctype(ctype) for ctype in signature)
 
-    # Check if we've already created a CFUNCTYPE for this encoding.
-    # If so, then return the cached CFUNCTYPE.
-    try:
-        cfunctype = cfunctype_table[types]
-    except KeyError:
-        cfunctype = cfunctype_table[types] = CFUNCTYPE(*signature)
-
+    cfunctype = CFUNCTYPE(*signature)
     imp = cfunctype(method)
     objc.class_addMethod(cls, selector, cast(imp, IMP), types)
     return imp

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -59,7 +59,7 @@ def encoding_to_ctype(encoding):
     """Return ctypes type for an encoded Objective-C type."""
     
     # Remove qualifiers, as documented in Table 6-2 here:
-    # https://developer.apple.com/library/prerelease/content/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+    # https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
     encoding = encoding.lstrip(b"NORVnor")
     
     try:

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -18,8 +18,6 @@ _any_arm = ('ARM' in platform.version())
 __arm64__ = (_any_arm and __LP64__)
 __arm__ = (_any_arm and not __LP64__)
 
-PyObjectEncoding = b'{PyObject=@}'
-
 
 def encoding_for_ctype(vartype):
     typecodes = {
@@ -44,6 +42,7 @@ if __LP64__:
     NSRangeEncoding = b'{_NSRange=QQ}'
     UIEdgeInsetsEncoding = b'{UIEdgeInsets=dddd}'
     NSEdgeInsetsEncoding = b'{NSEdgeInsets=dddd}'
+    PyObjectEncoding = b'^{_object=q^{_typeobject}}'
 else:
     NSInteger = c_int
     NSUInteger = c_uint
@@ -54,6 +53,7 @@ else:
     NSRangeEncoding = b'{_NSRange=II}'
     UIEdgeInsetsEncoding = b'{UIEdgeInsets=ffff}'
     NSEdgeInsetsEncoding = b'{NSEdgeInsets=ffff}'
+    PyObjectEncoding = b'^{_object=i^{_typeobject}}'
 
 NSIntegerEncoding = encoding_for_ctype(NSInteger)
 NSUIntegerEncoding = encoding_for_ctype(NSUInteger)

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -92,6 +92,17 @@ def register_preferred_encoding(encoding, ctype):
     _encoding_to_ctype_map[encoding] = ctype
     _ctype_to_encoding_map[ctype] = encoding
 
+def with_preferred_encoding(encoding):
+    """Decorator for registering a preferred conversion between the given encoding and the decorated type.
+    This is equivalent to calling register_preferred_encoding.
+    """
+    
+    def _with_preferred_encoding_decorator(ctype):
+        register_preferred_encoding(encoding, ctype)
+        return ctype
+    
+    return _with_preferred_encoding_decorator
+
 def register_encoding(encoding, ctype):
     """Register an additional conversion between an Objective-C type encoding and a ctypes type.
     If a conversion already exists in one or both directions, it is not overwritten.
@@ -99,6 +110,17 @@ def register_encoding(encoding, ctype):
     
     _encoding_to_ctype_map.setdefault(encoding, ctype)
     _ctype_to_encoding_map.setdefault(ctype, encoding)
+
+def with_encoding(encoding):
+    """Decorator for registering a conversion between the given encoding and the decorated type.
+    This is equivalent to calling register_encoding.
+    """
+    
+    def _with_encoding_decorator(ctype):
+        register_encoding(encoding, ctype)
+        return ctype
+    
+    return _with_encoding_decorator
 
 def unregister_encoding(encoding):
     """Unregister the conversion between an Objective-C type encoding and its corresponding ctypes type.
@@ -244,38 +266,38 @@ NSZoneEncoding = b'{_NSZone=}'
 register_preferred_encoding(PyObjectEncoding, py_object)
 
 
+@with_preferred_encoding(b'^?')
 class UnknownPointer(c_void_p):
     """Placeholder for the b'^?' "unknown pointer" type. Not to be confused with a b'^v' void pointer.
     Usually a b'^?' is a function pointer, but because the encoding doesn't contain the function signature, you need to manually create a CFUNCTYPE with the proper types, and cast this pointer to it.
     """
-register_preferred_encoding(b'^?', UnknownPointer)
 
 # from /System/Library/Frameworks/Foundation.framework/Headers/NSGeometry.h
+@with_preferred_encoding(NSPointEncoding)
 class NSPoint(Structure):
     _fields_ = [
         ("x", CGFloat),
         ("y", CGFloat)
     ]
 CGPoint = NSPoint
-register_preferred_encoding(NSPointEncoding, NSPoint)
 
 
+@with_preferred_encoding(NSSizeEncoding)
 class NSSize(Structure):
     _fields_ = [
         ("width", CGFloat),
         ("height", CGFloat)
     ]
 CGSize = NSSize
-register_preferred_encoding(NSSizeEncoding, NSSize)
 
 
+@with_preferred_encoding(NSRectEncoding)
 class NSRect(Structure):
     _fields_ = [
         ("origin", NSPoint),
         ("size", NSSize)
     ]
 CGRect = NSRect
-register_preferred_encoding(NSRectEncoding, NSRect)
 
 
 def NSMakeSize(w, h):
@@ -297,12 +319,12 @@ CGPointMake = NSMakePoint
 
 
 # iOS: /System/Library/Frameworks/UIKit.framework/Headers/UIGeometry.h
+@with_preferred_encoding(UIEdgeInsetsEncoding)
 class UIEdgeInsets(Structure):
     _fields_ = [('top', CGFloat),
                 ('left', CGFloat),
                 ('bottom', CGFloat),
                 ('right', CGFloat)]
-register_preferred_encoding(UIEdgeInsetsEncoding, UIEdgeInsets)
 
 def UIEdgeInsetsMake(top, left, bottom, right):
     return UIEdgeInsets(top, left, bottom, right)
@@ -311,12 +333,12 @@ UIEdgeInsetsZero = UIEdgeInsets(0, 0, 0, 0)
 
 
 # macOS: /System/Library/Frameworks/AppKit.framework/Headers/NSLayoutConstraint.h
+@with_preferred_encoding(NSEdgeInsetsEncoding)
 class NSEdgeInsets(Structure):
     _fields_ = [('top', CGFloat),
                 ('left', CGFloat),
                 ('bottom', CGFloat),
                 ('right', CGFloat)]
-register_preferred_encoding(NSEdgeInsetsEncoding, NSEdgeInsets)
 
 def NSEdgeInsetsMake(top, left, bottom, right):
     return NSEdgeInsets(top, left, bottom, right)
@@ -343,12 +365,12 @@ class CFRange(Structure):
 
 
 # NSRange.h  (Note, not defined the same as CFRange)
+@with_preferred_encoding(NSRangeEncoding)
 class NSRange(Structure):
     _fields_ = [
         ("location", NSUInteger),
         ("length", NSUInteger)
     ]
-register_preferred_encoding(NSRangeEncoding, NSRange)
 
 NSZeroPoint = NSPoint(0, 0)
 if sizeof(c_void_p) == 4:

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -21,10 +21,8 @@ __arm__ = (_any_arm and not __LP64__)
 
 _type_to_ctype_map = {
     int: c_int,
-    float: c_float,
+    float: c_double,
     bool: c_bool,
-    # This is not really correct - Python strings are Unicode - but we need to keep this for compatibility.
-    str: c_char_p,
     bytes: c_char_p,
 }
 

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -1106,7 +1106,7 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
     def test_setdefault1(self):
         d = self.make_dictionary(self.py_dict)
 
-        self.assertEqual(d.setdefault('one', 1), 'ONE')
+        self.assertEqual(d.setdefault('one', 'default'), 'ONE')
         self.assertEqual(len(d), len(self.py_dict))
 
     def test_setdefault2(self):

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -23,7 +23,7 @@ from rubicon.objc import (
     NSUInteger, NSRange, NSEdgeInsets, NSEdgeInsetsMake,
     send_message
 )
-from rubicon.objc import core_foundation
+from rubicon.objc import core_foundation, types
 from rubicon.objc.objc import ObjCBoundMethod
 
 
@@ -485,28 +485,22 @@ class RubiconTest(unittest.TestCase):
         Example = ObjCClass('Example')
         example = Example.alloc().init()
 
-        # FIXME: Overriding the restype like done below is NOT reliable - this code may need to be updated if the method lookup internals change. When #14 is fixed, there should be a better way of setting a custom restype (or it should be set correctly by default).
-
         class struct_int_sized(Structure):
             _fields_ = [("x", c_char * 4)]
+        types.register_encoding(b'{int_sized=[4c]}', struct_int_sized)
 
-        method = example.intSizedStruct
-        method.method.restype = struct_int_sized
-        self.assertEqual(method().x, b"abc")
-
+        self.assertEqual(example.intSizedStruct().x, b"abc")
         class struct_oddly_sized(Structure):
             _fields_ = [("x", c_char * 5)]
 
-        method = example.oddlySizedStruct
-        method.method.restype = struct_oddly_sized
-        self.assertEqual(method().x, b"abcd")
+        types.register_encoding(b'{oddly_sized=[5c]}', struct_oddly_sized)
+        self.assertEqual(example.oddlySizedStruct().x, b"abcd")
 
         class struct_large(Structure):
             _fields_ = [("x", c_char * 17)]
 
-        method = example.largeStruct
-        method.method.restype = struct_large
-        self.assertEqual(method().x, b"abcdefghijklmnop")
+        types.register_encoding(b'{large=[17c]}', struct_large)
+        self.assertEqual(example.largeStruct().x, b"abcdefghijklmnop")
 
     def test_struct_return_send(self):
         "Methods returning structs of different sizes by value can be handled when using send_message."


### PR DESCRIPTION
Fixes #14.

This moves most of the type-encoding-related code from `objc.py` to `types.py`, and adds a documented API for adding custom conversions between Objective-C type encodings and `ctypes` types.

The API may seem a bit overkill, but the complexity is unfortunately necessary, because it's not always possible to map exactly one Objective-C encoding to exactly one ctype. For example, all of `c_char_p`, `POINTER(c_char)`, `POINTER(c_byte)`, and `POINTER(c_ubyte)` have the encoding `*`. The same issue exists in the other direction - on a 64-bit machine, the encodings `l` and `q` both correspond to `c_long` (because `c_long == c_longlong` on 64-bit).

Because of this, there are two functions for registering an encoding/ctype mapping:

* `register_preferred_encoding(encoding, ctype)` registers conversions from `encoding` to `ctype` and vice versa, and replaces any existing conversions in each direction.
* `register_encoding(encoding, ctype)` does the same, but only adds the conversion for each direction if there isn't already one for that direction.

In many cases, encodings do map one-to-one to ctypes, and it doesn't make a difference which function is used. But sometimes one encoding needs to be explicitly set as preferred. For example, this:

```python
register_encoding(b'*', POINTER(c_byte))
register_encoding(b'*', c_char_p)
```

makes both `POINTER(c_byte)` and `c_char_p` encode to `*`, and `*` decode to `POINTER(c_byte)`. On the other hand, this:

```python
register_encoding(b'*', POINTER(c_byte))
register_preferred_encoding(b'*', c_char_p)
```

makes `*` decode to `c_char_p` instead, but still allows both `POINTER(c_byte)` and `c_char_p` to encode to `*`. (For some more examples of how this works in practice, see `types.py`, where all the primitive types are registered.)

That said, suggestions for improving the API or the documentation are welcome - I would have preferred to have fewer functions, but I couldn't figure out a simpler way to support all the corner cases well.