### PR TITLE
Clean up some old APIs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Changelog
 * Fixed the declaration of ``unichar`` (was previously ``c_wchar``, is now ``c_ushort``).
 * Removed the ``get_selector`` function. Use the ``SEL`` constructor instead.
 * Removed some runtime function declarations that are deprecated or unlikely to be useful.
+* Removed the encoding constants. Use ``encoding_for_ctype`` to get the encoding of a type.
 
 0.2.7
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@ Changelog
 * Added functions for declaring custom conversions between Objective-C type encodings and ``ctypes`` types.
 * Extended the Objective-C type encoding decoder to support block types as well as arbitrary qualifiers and pointers.
 * Changed the ``PyObjectEncoding`` to match the real definition of ``PyObject *``.
+* Fixed the declaration of ``unichar`` (was previously ``c_wchar``, is now ``c_ushort``).
+* Removed the ``get_selector`` function. Use the ``SEL`` constructor instead.
+* Removed some runtime function declarations that are deprecated or unlikely to be useful.
 
 0.2.7
 -----

--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -12,7 +12,6 @@ from .core_foundation import at, to_str, to_number, to_value, to_set, to_list
 from .types import (
     NSInteger, NSUInteger,
     CGFloat,
-    NSPointEncoding, NSSizeEncoding, NSRectEncoding, NSRangeEncoding, UIEdgeInsetsEncoding, NSEdgeInsetsEncoding,
     CGPoint, NSPoint,
     CGSize, NSSize,
     CGRect, NSRect,

--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -2,7 +2,6 @@ __version__ = '0.2.7'
 
 from .objc import (
     objc, send_message, send_super,
-    get_selector,
     SEL, objc_id, Class, IMP, Method, Ivar, objc_property_t,
     ObjCInstance, ObjCClass, ObjCMetaClass, NSObject,
     objc_ivar, objc_property, objc_rawmethod, objc_method, objc_classmethod

--- a/rubicon/objc/core_foundation.py
+++ b/rubicon/objc/core_foundation.py
@@ -4,7 +4,7 @@ from ctypes import *
 from ctypes import util
 from decimal import Decimal
 
-from .objc import ObjCClass, ObjCInstance, send_message, get_class, get_selector, objc, objc_id, SEL, Class
+from .objc import ObjCClass, ObjCInstance, send_message, get_class, objc, objc_id, SEL, Class
 from .types import *
 
 ######################################################################
@@ -189,7 +189,7 @@ class NSDecimalNumber(object):
     def from_decimal(cls, value):
         if cls.objc_class is None:
             cls.objc_class = get_class('NSDecimalNumber')
-            cls.selector = get_selector('decimalNumberWithString:')
+            cls.selector = SEL('decimalNumberWithString:')
             method = objc.class_getClassMethod(cls.objc_class, cls.selector)
             impl = objc.method_getImplementation(method)
             cls.constructor = cast(impl, CFUNCTYPE(objc_id, objc_id, SEL, objc_id))

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -435,11 +435,6 @@ def ensure_bytes(x):
 ######################################################################
 
 
-def get_selector(name):
-    "Return a reference to the selector with the given name."
-    return SEL(name)
-
-
 def get_class(name):
     "Return a reference to the class with the given name."
     return objc.objc_getClass(ensure_bytes(name))
@@ -516,7 +511,7 @@ def send_message(receiver, selName, *args, **kwargs):
     else:
         raise TypeError("Invalid type for receiver: {tp.__module__}.{tp.__qualname__}".format(tp=type(receiver)))
 
-    selector = get_selector(selName)
+    selector = SEL(selName)
     restype = kwargs.get('restype', c_void_p)
     argtypes = kwargs.get('argtypes', [])
 
@@ -559,7 +554,7 @@ def send_super(receiver, selName, *args, **kwargs):
         receiver = receiver._as_parameter_
     superclass = get_superclass_of_object(receiver)
     super_struct = OBJC_SUPER(receiver, superclass)
-    selector = get_selector(selName)
+    selector = SEL(selName)
     restype = kwargs.get('restype', c_void_p)
     argtypes = kwargs.get('argtypes', None)
 
@@ -604,7 +599,7 @@ def add_method(cls, selName, method, encoding):
     signature = tuple(ctype_for_type(tp) for tp in encoding)
     assert signature[1] == objc_id  # ensure id self typecode
     assert signature[2] == SEL  # ensure SEL cmd typecode
-    selector = get_selector(selName)
+    selector = SEL(selName)
     types = b"".join(encoding_for_ctype(ctype) for ctype in signature)
 
     cfunctype = CFUNCTYPE(*signature)

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -383,12 +383,12 @@ objc.protocol_conformsToProtocol.restype = c_bool
 objc.protocol_conformsToProtocol.argtypes = [objc_id, objc_id]
 
 
-class OBJC_METHOD_DESCRIPTION(Structure):
+class objc_method_description(Structure):
     _fields_ = [("name", SEL), ("types", c_char_p)]
 
 # struct objc_method_description *protocol_copyMethodDescriptionList(Protocol *p, BOOL isRequiredMethod, BOOL isInstanceMethod, unsigned int *outCount)
 # You must free() the returned array.
-objc.protocol_copyMethodDescriptionList.restype = POINTER(OBJC_METHOD_DESCRIPTION)
+objc.protocol_copyMethodDescriptionList.restype = POINTER(objc_method_description)
 objc.protocol_copyMethodDescriptionList.argtypes = [objc_id, c_bool, c_bool, POINTER(c_uint)]
 
 # objc_property_t * protocol_copyPropertyList(Protocol *protocol, unsigned int *outCount)
@@ -400,7 +400,7 @@ objc.protocol_copyProtocolList = POINTER(objc_id)
 objc.protocol_copyProtocolList.argtypes = [objc_id, POINTER(c_uint)]
 
 # struct objc_method_description protocol_getMethodDescription(Protocol *p, SEL aSel, BOOL isRequiredMethod, BOOL isInstanceMethod)
-objc.protocol_getMethodDescription.restype = OBJC_METHOD_DESCRIPTION
+objc.protocol_getMethodDescription.restype = objc_method_description
 objc.protocol_getMethodDescription.argtypes = [objc_id, SEL, c_bool, c_bool]
 
 # const char *protocol_getName(Protocol *p)
@@ -540,7 +540,7 @@ def send_message(receiver, selName, *args, **kwargs):
     return result
 
 
-class OBJC_SUPER(Structure):
+class objc_super(Structure):
     _fields_ = [('receiver', objc_id), ('super_class', Class)]
 
 
@@ -553,7 +553,7 @@ def send_super(receiver, selName, *args, **kwargs):
     if hasattr(receiver, '_as_parameter_'):
         receiver = receiver._as_parameter_
     superclass = get_superclass_of_object(receiver)
-    super_struct = OBJC_SUPER(receiver, superclass)
+    super_struct = objc_super(receiver, superclass)
     selector = SEL(selName)
     restype = kwargs.get('restype', c_void_p)
     argtypes = kwargs.get('argtypes', None)
@@ -561,7 +561,7 @@ def send_super(receiver, selName, *args, **kwargs):
     send = objc['objc_msgSendSuper']
     send.restype = restype
     if argtypes:
-        send.argtypes = [POINTER(OBJC_SUPER), SEL] + argtypes
+        send.argtypes = [POINTER(objc_super), SEL] + argtypes
     else:
         send.argtypes = None
     result = send(byref(super_struct), selector, *args)

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -145,10 +145,6 @@ objc.class_copyPropertyList.argtypes = [Class, POINTER(c_uint)]
 objc.class_copyProtocolList.restype = POINTER(objc_id)
 objc.class_copyProtocolList.argtypes = [Class, POINTER(c_uint)]
 
-# id class_createInstance(Class cls, size_t extraBytes)
-objc.class_createInstance.restype = objc_id
-objc.class_createInstance.argtypes = [Class, c_size_t]
-
 # Method class_getClassMethod(Class aClass, SEL aSelector)
 # Will also search superclass for implementations.
 objc.class_getClassMethod.restype = Method
@@ -178,10 +174,6 @@ objc.class_getIvarLayout.argtypes = [Class]
 # IMP class_getMethodImplementation(Class cls, SEL name)
 objc.class_getMethodImplementation.restype = IMP
 objc.class_getMethodImplementation.argtypes = [Class, SEL]
-
-# IMP class_getMethodImplementation_stret(Class cls, SEL name)
-#objc.class_getMethodImplementation_stret.restype = IMP
-#objc.class_getMethodImplementation_stret.argtypes = [Class, SEL]
 
 # const char * class_getName(Class cls)
 objc.class_getName.restype = c_char_p
@@ -218,10 +210,6 @@ objc.class_respondsToSelector.argtypes = [Class, SEL]
 # void class_setIvarLayout(Class cls, const char *layout)
 objc.class_setIvarLayout.restype = None
 objc.class_setIvarLayout.argtypes = [Class, c_char_p]
-
-# Class class_setSuperclass(Class cls, Class newSuper)
-objc.class_setSuperclass.restype = Class
-objc.class_setSuperclass.argtypes = [Class, Class]
 
 # void class_setVersion(Class theClass, int version)
 objc.class_setVersion.restype = None
@@ -311,11 +299,6 @@ objc.objc_getAssociatedObject.argtypes = [objc_id, c_void_p]
 objc.objc_getClass.restype = Class
 objc.objc_getClass.argtypes = [c_char_p]
 
-# int objc_getClassList(Class *buffer, int bufferLen)
-# Pass None for buffer to obtain just the total number of classes.
-objc.objc_getClassList.restype = c_int
-objc.objc_getClassList.argtypes = [POINTER(Class), c_int]
-
 # Class objc_getMetaClass(const char *name)
 objc.objc_getMetaClass.restype = Class
 objc.objc_getMetaClass.argtypes = [c_char_p]
@@ -355,14 +338,6 @@ objc.objc_setAssociatedObject.argtypes = [objc_id, c_void_p, objc_id, c_int]
 
 ######################################################################
 
-# id object_copy(id obj, size_t size)
-objc.object_copy.restype = objc_id
-objc.object_copy.argtypes = [objc_id, c_size_t]
-
-# id object_dispose(id obj)
-objc.object_dispose.restype = objc_id
-objc.object_dispose.argtypes = [objc_id]
-
 # BOOL object_isClass(id obj)
 objc.object_isClass.restype = c_bool
 objc.object_isClass.argtypes = [objc_id]
@@ -382,10 +357,6 @@ objc.object_getInstanceVariable.argtypes = [objc_id, c_char_p, POINTER(c_void_p)
 # id object_getIvar(id object, Ivar ivar)
 objc.object_getIvar.restype = objc_id
 objc.object_getIvar.argtypes = [objc_id, Ivar]
-
-# Class object_setClass(id object, Class cls)
-objc.object_setClass.restype = Class
-objc.object_setClass.argtypes = [objc_id, Class]
 
 # Ivar object_setInstanceVariable(id obj, const char *name, void *value)
 # Set argtypes based on the data type of the instance variable.
@@ -441,9 +412,6 @@ objc.protocol_getName.argtypes = [objc_id]
 # const char* sel_getName(SEL aSelector)
 objc.sel_getName.restype = c_char_p
 objc.sel_getName.argtypes = [SEL]
-
-# SEL sel_getUid(const char *str)
-# Use sel_registerName instead.
 
 # BOOL sel_isEqual(SEL lhs, SEL rhs)
 objc.sel_isEqual.restype = c_bool

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -235,35 +235,26 @@ if __LP64__:
     NSInteger = c_long
     NSUInteger = c_ulong
     CGFloat = c_double
-    NSPointEncoding = b'{CGPoint=dd}'
-    NSSizeEncoding = b'{CGSize=dd}'
-    NSRectEncoding = b'{CGRect={CGPoint=dd}{CGSize=dd}}'
-    NSRangeEncoding = b'{_NSRange=QQ}'
-    UIEdgeInsetsEncoding = b'{UIEdgeInsets=dddd}'
-    NSEdgeInsetsEncoding = b'{NSEdgeInsets=dddd}'
-    PyObjectEncoding = b'^{_object=q^{_typeobject}}'
+    _NSPointEncoding = b'{CGPoint=dd}'
+    _NSSizeEncoding = b'{CGSize=dd}'
+    _NSRectEncoding = b'{CGRect={CGPoint=dd}{CGSize=dd}}'
+    _NSRangeEncoding = b'{_NSRange=QQ}'
+    _UIEdgeInsetsEncoding = b'{UIEdgeInsets=dddd}'
+    _NSEdgeInsetsEncoding = b'{NSEdgeInsets=dddd}'
+    _PyObjectEncoding = b'^{_object=q^{_typeobject}}'
 else:
     NSInteger = c_int
     NSUInteger = c_uint
     CGFloat = c_float
-    NSPointEncoding = b'{CGPoint=ff}'
-    NSSizeEncoding = b'{CGSize=ff}'
-    NSRectEncoding = b'{CGRect={CGPoint=ff}{CGSize=ff}}'
-    NSRangeEncoding = b'{_NSRange=II}'
-    UIEdgeInsetsEncoding = b'{UIEdgeInsets=ffff}'
-    NSEdgeInsetsEncoding = b'{NSEdgeInsets=ffff}'
-    PyObjectEncoding = b'^{_object=i^{_typeobject}}'
+    _NSPointEncoding = b'{CGPoint=ff}'
+    _NSSizeEncoding = b'{CGSize=ff}'
+    _NSRectEncoding = b'{CGRect={CGPoint=ff}{CGSize=ff}}'
+    _NSRangeEncoding = b'{_NSRange=II}'
+    _UIEdgeInsetsEncoding = b'{UIEdgeInsets=ffff}'
+    _NSEdgeInsetsEncoding = b'{NSEdgeInsets=ffff}'
+    _PyObjectEncoding = b'^{_object=i^{_typeobject}}'
 
-NSIntegerEncoding = encoding_for_ctype(NSInteger)
-NSUIntegerEncoding = encoding_for_ctype(NSUInteger)
-CGFloatEncoding = encoding_for_ctype(CGFloat)
-
-# Special case so that NSImage.initWithCGImage_size_() will work.
-CGImageEncoding = b'{CGImage=}'
-
-NSZoneEncoding = b'{_NSZone=}'
-
-register_preferred_encoding(PyObjectEncoding, py_object)
+register_preferred_encoding(_PyObjectEncoding, py_object)
 
 
 @with_preferred_encoding(b'^?')
@@ -273,7 +264,7 @@ class UnknownPointer(c_void_p):
     """
 
 # from /System/Library/Frameworks/Foundation.framework/Headers/NSGeometry.h
-@with_preferred_encoding(NSPointEncoding)
+@with_preferred_encoding(_NSPointEncoding)
 class NSPoint(Structure):
     _fields_ = [
         ("x", CGFloat),
@@ -282,7 +273,7 @@ class NSPoint(Structure):
 CGPoint = NSPoint
 
 
-@with_preferred_encoding(NSSizeEncoding)
+@with_preferred_encoding(_NSSizeEncoding)
 class NSSize(Structure):
     _fields_ = [
         ("width", CGFloat),
@@ -291,7 +282,7 @@ class NSSize(Structure):
 CGSize = NSSize
 
 
-@with_preferred_encoding(NSRectEncoding)
+@with_preferred_encoding(_NSRectEncoding)
 class NSRect(Structure):
     _fields_ = [
         ("origin", NSPoint),
@@ -319,7 +310,7 @@ CGPointMake = NSMakePoint
 
 
 # iOS: /System/Library/Frameworks/UIKit.framework/Headers/UIGeometry.h
-@with_preferred_encoding(UIEdgeInsetsEncoding)
+@with_preferred_encoding(_UIEdgeInsetsEncoding)
 class UIEdgeInsets(Structure):
     _fields_ = [('top', CGFloat),
                 ('left', CGFloat),
@@ -333,7 +324,7 @@ UIEdgeInsetsZero = UIEdgeInsets(0, 0, 0, 0)
 
 
 # macOS: /System/Library/Frameworks/AppKit.framework/Headers/NSLayoutConstraint.h
-@with_preferred_encoding(NSEdgeInsetsEncoding)
+@with_preferred_encoding(_NSEdgeInsetsEncoding)
 class NSEdgeInsets(Structure):
     _fields_ = [('top', CGFloat),
                 ('left', CGFloat),
@@ -365,7 +356,7 @@ class CFRange(Structure):
 
 
 # NSRange.h  (Note, not defined the same as CFRange)
-@with_preferred_encoding(NSRangeEncoding)
+@with_preferred_encoding(_NSRangeEncoding)
 class NSRange(Structure):
     _fields_ = [
         ("location", NSUInteger),

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -351,7 +351,7 @@ NSTimeInterval = c_double
 
 CFIndex = c_long
 UniChar = c_ushort
-unichar = c_wchar  # (actually defined as c_ushort in NSString.h, but need ctypes to convert properly)
+unichar = c_ushort
 CGGlyph = c_ushort
 
 


### PR DESCRIPTION
This removes some old APIs that are no longer necessary, and fixes a few other small issues. This is of course a breaking change - maybe it would be a good idea to wait with merging this until 0.3.0 (or make 0.3.0 the next version).

* Removed some runtime function declarations that are either deprecated or unlikely to be useful (see ccdb7a3960167501004c7599216bc15b84d8f67f for details).
* Removed `get_selector`, which did exactly the same as the `SEL` constructor.
* Changed the names of `OBJC_METHOD_DESCRIPTION` and `OBJC_SUPER` to be lowercase instead of uppercase, to match the names in the real header.
* Fixed the `unichar` type, which was incorrectly set to `c_wchar` instead of `c_ushort`. (The two types have different sizes.)
* Removed the encoding constants from the `types` module (some are private, others removed completely) in favor of `encoding_for_ctype`. The latter works with all registered types, including aliases like `CGPoint`/`NSPoint`, and doesn't require any extra manual declarations.