### PR TITLE
Automatic array/struct/union type creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 * Added support for using native Python sequence/mapping syntax with ``NSArray`` and ``NSDictionary``. (jeamland)
 * Added functions for declaring custom conversions between Objective-C type encodings and ``ctypes`` types.
-* Extended the Objective-C type encoding decoder to support block types as well as arbitrary qualifiers and pointers.
+* Extended the Objective-C type encoding decoder to support block types, bit fields (in structures), typed object pointers, and arbitrary qualifiers. If unknown pointer, array, struct or union types are encountered, they are created and registered on the fly.
 * Changed the ``PyObjectEncoding`` to match the real definition of ``PyObject *``.
 * Fixed the declaration of ``unichar`` (was previously ``c_wchar``, is now ``c_ushort``).
 * Removed the ``get_selector`` function. Use the ``SEL`` constructor instead.

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -55,7 +55,8 @@ _encoding_for_ctype_map = {}
 
 def _end_of_encoding(encoding, start):
     """Find the end index of the encoding starting at index start.
-    The encoding is not validated very extensively. There are no guarantees what happens for invalid encodings - an error may be raised, or a bogus end index may be returned.
+    The encoding is not validated very extensively. There are no guarantees what happens for invalid encodings;
+    an error may be raised, or a bogus end index may be returned.
     """
     
     if start < 0 or start >= len(encoding):

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -53,6 +53,172 @@ def get_ctype_for_type_map():
 _ctype_for_encoding_map = {}
 _encoding_for_ctype_map = {}
 
+def _end_of_encoding(encoding, start):
+    """Find the end index of the encoding starting at index start.
+    The encoding is not validated very extensively. There are no guarantees what happens for invalid encodings - an error may be raised, or a bogus end index may be returned.
+    """
+    
+    if start < 0 or start >= len(encoding):
+        raise ValueError('Start index {} not in range({})'.format(start, len(encoding)))
+    
+    paren_depth = 0
+    
+    i = start
+    while i < len(encoding):
+        c = encoding[i:i+1]
+        if paren_depth > 0:
+            if c in b')]}>':
+                # Closing parentheses of some type.
+                paren_depth -= 1
+                if paren_depth == 0:
+                    # Final closing parenthesis, end of this encoding.
+                    return i+1
+            else:
+                # Some other character, do nothing because we are in parentheses.
+                i += 1
+        elif c in b'*:#?BCDILQSTcdfilqstv':
+            # Encodings with exactly one character.
+            return i+1
+        elif c in b'^ANORVjnor':
+            # Simple prefix (qualifier, pointer, etc.), skip it but count it towards the length.
+            i += 1
+        elif c in b'([{<':
+            # Opening parenthesis of some type, wait for a corresponding closing paren.
+            # This doesn't check that the parenthesis *types* match (only the *number* of closing parens has to match).
+            paren_depth += 1
+        elif c == b'@':
+            if encoding[i+1:i+3] == b'?<':
+                # Encoding @?<...> (block with signature).
+                # Skip the @? and continue at the < which is treated as an opening paren.
+                i += 2
+            elif encoding[i+1:i+2] == b'?':
+                # Encoding @? (block).
+                return i+2
+            elif encoding[i+1:i+2] == b'"':
+                # Encoding @"..." (object pointer with class name).
+                return encoding.index(b'"', i+2)+1
+            else:
+                # Encoding @ (untyped object pointer).
+                return i+1
+        elif c == b'b':
+            # Bit field, followed by one or more digits.
+            for j in range(i+1, len(encoding)):
+                if encoding[j] not in b'0123456789':
+                    # Found a non-digit, stop here.
+                    return j
+            # Reached end of string without finding a non-digit, stop.
+            return len(encoding)
+        else:
+            raise ValueError('Unknown encoding {} at index {}: {}'.format(c, i, encoding))
+    
+    if paren_depth > 0:
+        raise ValueError('Incomplete encoding, missing {} closing parentheses: {}'.format(paren_depth, encoding))
+    else:
+        raise ValueError('Incomplete encoding, reached end of string too early: {}'.format(encoding))
+
+def _create_structish_type_for_encoding(encoding, *, base):
+    """Create a structish type from the given encoding. ("structish" = "structure or union")
+    The base kwarg controls which base class is used. It should be either ctypes.Structure or ctypes.Union.
+    """
+    
+    # Split name and fields.
+    begin = encoding[0:1]
+    end = encoding[-1:len(encoding)]
+    name, eq, fields = encoding[1:-1].partition(b'=')
+    
+    if not eq:
+        # If the fields are not present, we can't create a meaningful structish.
+        # We also know that there is no known structish with this name,
+        # because in that case that structish would have been found by ctype_for_encoding.
+        # So we pretend that this structish is a void (None).
+        # This causes pointers to it to become void pointers.
+        return None
+    
+    if name == b'?':
+        # Anonymous structish, has no name.
+        name = None
+
+    # Create the subclass. The _fields_ are not set yet, this is done later.
+    # The structish is already registered here, so that pointers to this structish type in itself are typed correctly.
+    py_name = '_Anonymous' if name is None else name.decode('utf-8')
+    structish_type = type(py_name, (base,), {})
+    # Register the structish for its own encoding, so the same type is used in the future.
+    register_encoding(encoding, structish_type)
+    if name is not None:
+        # If not anonymous, also register for the corresponding name-only encoding.
+        register_encoding(begin + name + end, structish_type)
+    
+    # Convert the field encodings to a sequence of tuples, as needed for the _fields_ attribute.
+    ctypes_fields = []
+    start = 0 # Start of the next field.
+    i = 0 # Field counter, used when naming unnamed fields.
+    while start < len(fields):
+        if fields[start:start+1] == b'"':
+            # If a name is present, use it.
+            field_name_end = fields.index(b'"', start+2)
+            field_name = fields[start+1:field_name_end].decode('utf-8')
+            start = field_name_end+1
+        else:
+            # If no name is present, make one based on the field index.
+            field_name = 'field_{}'.format(i)
+        end = _end_of_encoding(fields, start)
+        field_encoding = fields[start:end]
+        if field_encoding.startswith(b'b'):
+            # Bit field, extract the number of bits.
+            bit_field_size = int(field_encoding[1:])
+            ctypes_fields.append((field_name, c_uint, bit_field_size))
+        else:
+            # Regular field, decode the encoding normally.
+            field_type = ctype_for_encoding(field_encoding)
+            ctypes_fields.append((field_name, field_type))
+        start = end
+        i += 1
+    
+    structish_type._fields_ = ctypes_fields
+    
+    return structish_type
+
+def _ctype_for_unknown_encoding(encoding):
+    if encoding.startswith(b'^'):
+        # Resolve pointer types recursively.
+        pointer_type = POINTER(ctype_for_encoding(encoding[1:]))
+        register_encoding(encoding, pointer_type)
+        return pointer_type
+    elif encoding.startswith(b'[') and encoding.endswith(b']'):
+        # Resolve array types recursively.
+        for i, c in enumerate(encoding[1:], start=1):
+            if c not in b'0123456789':
+                break
+        assert i != 1
+        array_length = int(encoding[1:i].decode('utf-8'))
+        array_type = ctype_for_encoding(encoding[i:-1]) * array_length
+        register_encoding(encoding, array_type)
+        return array_type
+    elif encoding.startswith(b'{') and encoding.endswith(b'}'):
+        # Create ctypes.Structure subclasses for unknown structures.
+        return _create_structish_type_for_encoding(encoding, base=Structure)
+    elif encoding.startswith(b'(') and encoding.endswith(b')'):
+        # Create ctypes.Union subclasses for unknown unions.
+        return _create_structish_type_for_encoding(encoding, base=Union)
+    elif encoding.startswith(b'@?<') and encoding.endswith(b'>'):
+        # Ignore block signature encoding if present.
+        return ctype_for_encoding(b'@?')
+    elif encoding.startswith(b'@"') and encoding.endswith(b'"'):
+        # Ignore object pointer class names if present.
+        return ctype_for_encoding(b'@')
+    elif encoding.startswith(b'b'):
+        raise ValueError('A bit field encoding cannot appear outside a structure: %s' % (encoding,))
+    elif encoding.startswith(b'?'):
+        raise ValueError('An unknown encoding cannot appear outside of a pointer: %s' % (encoding,))
+    elif encoding.startswith(b'T') or encoding.startswith(b't'):
+        raise ValueError('128-bit integers are not supported by ctypes: %s' % (encoding,))
+    elif encoding.startswith(b'j'):
+        raise ValueError('Complex numbers are not supported by ctypes: %s' % (encoding,))
+    elif encoding.startswith(b'A'):
+        raise ValueError('Atomic types are not supported by ctypes: %s' % (encoding,))
+    else:
+        raise ValueError('Unknown encoding: %s' % (encoding,))
+
 def ctype_for_encoding(encoding):
     """Return ctypes type for an encoded Objective-C type."""
     
@@ -61,20 +227,10 @@ def ctype_for_encoding(encoding):
     encoding = encoding.lstrip(b"NORVnor")
     
     try:
-        # Look up simple type encodings directly
+        # Look up known type encodings directly.
         return _ctype_for_encoding_map[encoding]
     except KeyError:
-        if encoding[0:1] == b'^':
-            try:
-                # Try to resolve pointer types recursively
-                target = ctype_for_encoding(encoding[1:])
-            except ValueError:
-                # For unknown pointer types, fall back to c_void_p (this is not ideal, but at least it works instead of erroring)
-                return c_void_p
-            else:
-                return POINTER(target)
-        else:
-            raise ValueError('Unknown encoding: %s' % (encoding,))
+        return _ctype_for_unknown_encoding(encoding)
 
 def encoding_for_ctype(ctype):
     """Return the Objective-C type encoding for the given ctypes type."""
@@ -129,7 +285,7 @@ def unregister_encoding(encoding):
     If encoding was not registered previously, nothing happens.
     """
     
-    _ctype_for_encoding_map.pop(encoding, default=None)
+    _ctype_for_encoding_map.pop(encoding, None)
     
 
 def unregister_encoding_all(encoding):
@@ -138,7 +294,7 @@ def unregister_encoding_all(encoding):
     If encoding was not registered previously, nothing happens.
     """
     
-    _ctype_for_encoding_map.pop(encoding, default=None)
+    _ctype_for_encoding_map.pop(encoding, None)
     for ct, enc in list(_encoding_for_ctype_map.items()):
         if enc == encoding:
             unregister_ctype_all(ct)
@@ -226,6 +382,11 @@ register_encoding(b'^i', c_wchar_p)
 register_preferred_encoding(b'^i', POINTER(c_int))
 
 register_preferred_encoding(b'^v', c_void_p)
+
+# Anonymous structs/unions with unknown fields can't be decoded meaningfully,
+# so we treat pointers to them like void pointers.
+register_encoding(b'^{?}', c_void_p)
+register_encoding(b'^(?)', c_void_p)
 
 
 # Note CGBase.h located at

--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -4,6 +4,21 @@
 #import "Thing.h"
 #import "Callback.h"
 
+struct simple {
+	int foo;
+	int bar;
+};
+
+struct complex {
+	short things[4];
+	void (*callback)(void);
+	struct simple s;
+	struct complex *next;
+	unsigned int bitfield0:8;
+	unsigned int bitfield1:16;
+	unsigned int bitfield2:8;
+};
+
 /* objc_msgSend on i386, x86_64, ARM64; objc_msgSend_stret on ARM32. */
 struct int_sized {
     char data[4];
@@ -82,5 +97,7 @@ struct large {
 +(NSUInteger) overloaded;
 +(NSUInteger) overloaded:(NSUInteger)arg1;
 +(NSUInteger) overloaded:(NSUInteger)arg1 extraArg:(NSUInteger)arg2;
+
++(struct complex) doStuffWithStruct:(struct simple)simple;
 
 @end

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -216,4 +216,17 @@ static int _staticIntField = 11;
     return arg1 + arg2;
 }
 
++(struct complex) doStuffWithStruct:(struct simple)simple
+{
+    return (struct complex){
+        .things = {1, 2, 3, 4},
+        .callback = NULL,
+        .s = simple,
+        .next = NULL,
+        .bitfield0 = 0,
+        .bitfield1 = 1,
+        .bitfield2 = 2,
+    };
+}
+
 @end

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -3,14 +3,13 @@ from ctypes import util
 from decimal import Decimal
 from enum import Enum
 import functools
-import itertools
 import math
 import unittest
 
 try:
     import platform
     OSX_VERSION = tuple(int(v) for v in platform.mac_ver()[0].split('.')[:2])
-except:
+except Exception:
     OSX_VERSION = None
 
 import faulthandler
@@ -32,13 +31,6 @@ harnesslib = util.find_library('rubiconharness')
 if harnesslib is None:
     raise RuntimeError("Couldn't load Rubicon test harness library. Have you set DYLD_LIBRARY_PATH?")
 cdll.LoadLibrary(harnesslib)
-
-import sys
-import platform
-print("sys.platform = " + repr(sys.platform))
-print("platform.machine() = " + repr(platform.machine()))
-print("platform.version() = " + repr(platform.version()))
-print("sys.maxsize = " + hex(sys.maxsize))
 
 
 class RubiconTest(unittest.TestCase):
@@ -793,7 +785,8 @@ class NSArrayMixinTest(unittest.TestCase):
         for pos, value in enumerate(self.py_list):
             self.assertEqual(a[pos], value)
 
-        self.assertRaises(IndexError, lambda: a[len(self.py_list) + 10])
+        with self.assertRaises(IndexError):
+            a[len(self.py_list) + 10]
 
     def test_len(self):
         a = self.make_array(self.py_list)
@@ -818,7 +811,8 @@ class NSArrayMixinTest(unittest.TestCase):
     def test_index(self):
         a = self.make_array(self.py_list)
         self.assertEqual(a.index('two'), 1)
-        self.assertRaises(ValueError, lambda: a.index('umpteen'))
+        with self.assertRaises(ValueError):
+            a.index('umpteen')
 
     def test_count(self):
         a = self.make_array(self.py_list)
@@ -830,7 +824,8 @@ class NSArrayMixinTest(unittest.TestCase):
         self.assertEqual(b, a)
         self.assertEqual(b, self.py_list)
 
-        self.assertRaises(AttributeError, lambda: b.append('four'))
+        with self.assertRaises(AttributeError):
+            b.append('four')
 
     def test_equivalence(self):
         a = self.make_array(self.py_list)
@@ -922,12 +917,12 @@ class NSMutableArrayMixinTest(NSArrayMixinTest):
         a.remove('three')
         self.assertEqual(len(a), 2)
         self.assertEqual(a[-1], 'two')
-        self.assertRaises(ValueError, lambda: a.remove('umpteen'))
+        with self.assertRaises(ValueError):
+            a.remove('umpteen')
 
     def test_slice_assignment1(self):
         a = self.make_array(self.py_list * 2)
         a[2:4] = ['four', 'five']
-        print(list(a))
         self.assertEqual(a, ['one', 'two', 'four', 'five', 'two', 'three'])
 
     def test_slice_assignment2(self):
@@ -943,18 +938,14 @@ class NSMutableArrayMixinTest(NSArrayMixinTest):
     def test_bad_slice_assignment1(self):
         a = self.make_array(self.py_list * 2)
 
-        def doomed1():
+        with self.assertRaises(TypeError):
             a[2:4] = 4
-
-        self.assertRaises(TypeError, doomed1)
 
     def test_bad_slice_assignment2(self):
         a = self.make_array(self.py_list * 2)
 
-        def doomed1():
+        with self.assertRaises(ValueError):
             a[::2] = [4]
-
-        self.assertRaises(ValueError, doomed1)
 
     def test_del_slice1(self):
         a = self.make_array(self.py_list * 2)
@@ -1011,7 +1002,8 @@ class NSDictionaryMixinTest(unittest.TestCase):
         for key, value in self.py_dict.items():
             self.assertEqual(d[key], value)
 
-        self.assertRaises(KeyError, lambda: d['NO SUCH KEY'])
+        with self.assertRaises(KeyError):
+            d['NO SUCH KEY']
 
     def test_iter(self):
         d = self.make_dictionary(self.py_dict)
@@ -1047,9 +1039,8 @@ class NSDictionaryMixinTest(unittest.TestCase):
         self.assertEqual(e, d)
         self.assertEqual(e, self.py_dict)
 
-        def doomed():
+        with self.assertRaises(TypeError):
             e['four'] = 'FOUR'
-        self.assertRaises(TypeError, doomed)
 
     def test_keys(self):
         a = self.make_dictionary(self.py_dict)
@@ -1088,7 +1079,8 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
         d = self.make_dictionary(self.py_dict)
         del d['one']
         self.assertEqual(len(d), 2)
-        self.assertRaises(KeyError, lambda: d['one'])
+        with self.assertRaises(KeyError):
+            d['one']
 
     def test_clear(self):
         d = self.make_dictionary(self.py_dict)
@@ -1101,7 +1093,6 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
         self.assertEqual(e, d)
         self.assertEqual(e, self.py_dict)
 
-        print(repr(e))
         e['four'] = 'FOUR'
 
     def test_pop1(self):
@@ -1109,12 +1100,14 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
 
         self.assertEqual(d.pop('one'), 'ONE')
         self.assertEqual(len(d), 2)
-        self.assertRaises(KeyError, lambda: d['one'])
+        with self.assertRaises(KeyError):
+            d['one']
 
     def test_pop2(self):
         d = self.make_dictionary(self.py_dict)
 
-        self.assertRaises(KeyError, lambda: d.pop('four'))
+        with self.assertRaises(KeyError):
+            d.pop('four')
 
     def test_pop3(self):
         d = self.make_dictionary(self.py_dict)
@@ -1152,7 +1145,8 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
         self.assertTrue('four' not in d)
         self.assertEqual(d.setdefault('four'), None)
         self.assertEqual(len(d), len(self.py_dict))
-        self.assertRaises(KeyError, lambda: d['four'])
+        with self.assertRaises(KeyError):
+            d['four']
 
     def test_update1(self):
         d = self.make_dictionary(self.py_dict)


### PR DESCRIPTION
This extends `rubicon.objc.types.ctype_for_encoding` to automatically create array, struct and union types if they aren't registered yet. This means that methods with complicated types in their signature can now be used without having to first define and register all of them.

The auto-generated struct/union types often don't have useful field names - if a field doesn't have a name in the encoding, `field_n` is substituted (where `n` is a number counting up from zero). It is possible to compile Objective-C code in a way that also includes field names in structure/union encodings, and some of Apple's frameworks are compiled in that way. I haven't been able to get Clang to do that though. The only thing I've found is the flag `-Xclang -fencode-extended-block-signature`, but that didn't seem to change the encodings at all.

I've also added support for some other unusual encodings, like typed object pointers (`@"NSString"`), typed block pointers `@?<signature>`, and error messages for types not supported by `ctypes` (128-bit integers, complex numbers, atomic types).

Most of the details about the encoding format are taken from the `ASTContext::getObjCEncodingForTypeImpl` method from [`AST/ASTContext.h`](https://llvm.org/svn/llvm-project/cfe/trunk/lib/AST/ASTContext.cpp) from the Clang source code.