### PR TITLE
Added rudimentary objc block support for method arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OBJ_FILES=tests/objc/Thing.o tests/objc/Example.o tests/objc/BaseExample.o
+OBJ_FILES=tests/objc/Thing.o tests/objc/Example.o tests/objc/BaseExample.o tests/objc/Blocks.o
 
 # By default, build a universal i386/x86_64 binary.
 # Modify here (or on the command line) to build for other architecture(s).

--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -4,7 +4,8 @@ from .objc import (
     objc, send_message, send_super,
     SEL, objc_id, Class, IMP, Method, Ivar, objc_property_t,
     ObjCInstance, ObjCClass, ObjCMetaClass, NSObject,
-    objc_ivar, objc_property, objc_rawmethod, objc_method, objc_classmethod
+    objc_ivar, objc_property, objc_rawmethod, objc_method, objc_classmethod,
+    ObjCBlock
 )
 
 from .core_foundation import at, to_str, to_number, to_value, to_set, to_list

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -1652,15 +1652,51 @@ class ObjCBlockStruct(Structure):
         ('flags', c_int),
         ('reserved', c_int),
         ('invoke', CFUNCTYPE(c_void_p, c_void_p)),
+        ('descriptor', c_void_p),
     ]
+
+
+def cast_block_descriptor(block):
+    descriptor_fields = [
+        ('reserved', c_ulong),
+        ('size', c_ulong),
+    ]
+    if block.has_helpers:
+        descriptor_fields.extend([
+            ('copy_helper', CFUNCTYPE(c_void_p, c_void_p, c_void_p)),
+            ('dispose_helper', CFUNCTYPE(c_void_p, c_void_p)),
+        ])
+    if block.has_signature:
+        descriptor_fields.extend([
+            ('signature', c_char_p),
+        ])
+    descriptor_struct = type(
+        'ObjCBlockDescriptor',
+        (Structure, ),
+        {'_fields_': descriptor_fields}
+    )
+    return cast(block.struct.contents.descriptor, POINTER(descriptor_struct))
 
 
 class ObjCBlock:
     def __init__(self, instance, return_type, *arg_types):
         self.instance = instance
-        self.block = cast(self.instance.ptr, POINTER(ObjCBlockStruct))
-        self.block.contents.invoke.restype = return_type
-        self.block.contents.invoke.argtypes = arg_types
+        self.struct = cast(self.instance.ptr, POINTER(ObjCBlockStruct))
+        self.struct.contents.invoke.restype = return_type
+        self.struct.contents.invoke.argtypes = (objc_id, ) + arg_types
+        self.has_helpers = self.struct.contents.flags & (1<<25)
+        self.has_signature = self.struct.contents.flags & (1<<30)
+        self.descriptor = cast_block_descriptor(self)
+        self.signature = self.descriptor.contents.signature.decode('ascii') if self.has_signature else None
+
+    def __repr__(self):
+        representation = '<ObjCBlock@{}'.format(hex(addressof(self.instance.ptr)))
+        if self.has_helpers:
+            representation += ',has_helpers'
+        if self.has_signature:
+            representation += ',has_signature:' + self.signature
+        representation += '>'
+        return representation
 
     def __call__(self, *args):
-        return self.block.contents.invoke(self.instance.ptr, *args)
+        return self.struct.contents.invoke(self.instance.ptr, *args)

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -1682,8 +1682,8 @@ class ObjCBlock:
     def __init__(self, instance, return_type, *arg_types):
         self.instance = instance
         self.struct = cast(self.instance.ptr, POINTER(ObjCBlockStruct))
-        self.struct.contents.invoke.restype = return_type
-        self.struct.contents.invoke.argtypes = (objc_id, ) + arg_types
+        self.struct.contents.invoke.restype = ctype_for_type(return_type)
+        self.struct.contents.invoke.argtypes = (objc_id, ) + tuple(ctype_for_type(arg_type) for arg_type in arg_types)
         self.has_helpers = self.struct.contents.flags & (1<<25)
         self.has_signature = self.struct.contents.flags & (1<<30)
         self.descriptor = cast_block_descriptor(self)

--- a/tests/objc/Blocks.h
+++ b/tests/objc/Blocks.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+@interface BlockPropertyExample : NSObject
+@property (copy) int (^blockProperty)(int, int);
+@end
+
+
+@interface BlockDelegate : NSObject
+- (void)exampleMethod:(void (^)(int, int))blockArgument;
+@end
+
+@interface BlockObjectExample : NSObject
+@property int value;
+@property BlockDelegate *delegate;
+- (id)initWithDelegate:(BlockDelegate *)delegate;
+- (int)blockExample;
+@end

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -1,0 +1,39 @@
+#import "Blocks.h"
+
+@implementation BlockPropertyExample
+
+-(id) init
+{
+    self = [super init];
+
+    if (self) {
+        self.blockProperty = ^(int a, int b){
+            return a + b;
+        };
+    }
+    return self;
+}
+
+@end
+
+@implementation BlockObjectExample
+
+-(id) initWithDelegate:(BlockDelegate *)delegate
+{
+  self = [super init];
+  if (self) {
+    self.delegate = delegate;
+  }
+  return self;
+}
+
+-(int) blockExample {
+  BlockDelegate *delegate = self.delegate;
+  NSLog(@"Delegate is: %@", delegate);
+
+  [delegate exampleMethod:^(int a, int b){
+    self.value = a + b;
+  }];
+  return self.value;
+}
+@end

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -29,7 +29,6 @@
 
 -(int) blockExample {
     BlockDelegate *delegate = self.delegate;
-    NSLog(@"Delegate is: %@", delegate);
 
     [delegate exampleMethod:^(int a, int b){
         self.value = a + b;

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -20,20 +20,20 @@
 
 -(id) initWithDelegate:(BlockDelegate *)delegate
 {
-  self = [super init];
-  if (self) {
-    self.delegate = delegate;
-  }
-  return self;
+    self = [super init];
+    if (self) {
+        self.delegate = delegate;
+    }
+    return self;
 }
 
 -(int) blockExample {
-  BlockDelegate *delegate = self.delegate;
-  NSLog(@"Delegate is: %@", delegate);
+    BlockDelegate *delegate = self.delegate;
+    NSLog(@"Delegate is: %@", delegate);
 
-  [delegate exampleMethod:^(int a, int b){
-    self.value = a + b;
-  }];
-  return self.value;
+    [delegate exampleMethod:^(int a, int b){
+        self.value = a + b;
+    }];
+    return self.value;
 }
 @end

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -1162,19 +1162,36 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
 
 
 class BlockTests(unittest.TestCase):
-    def test_block_property(self):
+    def test_block_property_ctypes(self):
         BlockPropertyExample = ObjCClass("BlockPropertyExample")
         instance = BlockPropertyExample.alloc().init()
         result = ObjCBlock(instance.blockProperty, c_int, c_int, c_int)(1, 2)
         self.assertEqual(result, 3)
 
-    def test_block_delegate_method_manual(self):
-        class DelegateManual(NSObject):
+    def test_block_property_pytypes(self):
+        BlockPropertyExample = ObjCClass("BlockPropertyExample")
+        instance = BlockPropertyExample.alloc().init()
+        result = ObjCBlock(instance.blockProperty, int, int, int)(1, 2)
+        self.assertEqual(result, 3)
+
+    def test_block_delegate_method_manual_ctypes(self):
+        class DelegateManualC(NSObject):
             @objc_method
             def exampleMethod_(self, block):
                 ObjCBlock(block, c_void_p, c_int, c_int)(2, 3)
         BlockObjectExample = ObjCClass("BlockObjectExample")
-        delegate = DelegateManual.alloc().init()
+        delegate = DelegateManualC.alloc().init()
+        instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
+        result = instance.blockExample()
+        self.assertEqual(result, 5)
+
+    def test_block_delegate_method_manual_pytypes(self):
+        class DelegateManualPY(NSObject):
+            @objc_method
+            def exampleMethod_(self, block):
+                ObjCBlock(block, None, int, int)(2, 3)
+        BlockObjectExample = ObjCClass("BlockObjectExample")
+        delegate = DelegateManualPY.alloc().init()
         instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
         result = instance.blockExample()
         self.assertEqual(result, 5)

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -21,7 +21,7 @@ from rubicon.objc import (
     NSObject, SEL,
     objc, objc_method, objc_classmethod, objc_property,
     NSUInteger, NSRange, NSEdgeInsets, NSEdgeInsetsMake,
-    send_message
+    send_message, ObjCBlock
 )
 from rubicon.objc import core_foundation, types
 from rubicon.objc.objc import ObjCBoundMethod
@@ -1160,3 +1160,21 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
         self.assertEqual(d['four'], 'FIVE')
         self.assertEqual(len(d), len(self.py_dict) + 1)
 
+
+class BlockTests(unittest.TestCase):
+    def test_block_property(self):
+        BlockPropertyExample = ObjCClass("BlockPropertyExample")
+        instance = BlockPropertyExample.alloc().init()
+        result = ObjCBlock(instance.blockProperty, c_int, c_int, c_int)(1, 2)
+        self.assertEqual(result, 3)
+
+    def test_block_delegate_method_manual(self):
+        class DelegateManual(NSObject):
+            @objc_method
+            def exampleMethod_(self, block):
+                ObjCBlock(block, c_void_p, c_int, c_int)(2, 3)
+        BlockObjectExample = ObjCClass("BlockObjectExample")
+        delegate = DelegateManual.alloc().init()
+        instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
+        result = instance.blockExample()
+        self.assertEqual(result, 5)


### PR DESCRIPTION
Adds support to call objc-blocks that are arguments to nsobjects defined in Python or are properties of objects in objc. Does *not* add support to create your own objc-blocks to pass to objc.

Usage:

```
# `instance` is an instance of ObjCInstance we got from objc
# The block signature is assumed to be `(void (^)(int, int))`
block = ObjCBlock(instance, c_void_p, c_int, c_int)
block(1, 2)
```