### PR TITLE
Support for receiving objc blocks as argument to python methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OBJ_FILES=tests/objc/Thing.o tests/objc/Example.o tests/objc/BaseExample.o
+OBJ_FILES=tests/objc/Thing.o tests/objc/Example.o tests/objc/BaseExample.o tests/objc/Blocks.o
 
 # By default, build a universal i386/x86_64 binary.
 # Modify here (or on the command line) to build for other architecture(s).

--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -4,7 +4,8 @@ from .objc import (
     objc, send_message, send_super,
     SEL, objc_id, Class, IMP, Method, Ivar, objc_property_t,
     ObjCInstance, ObjCClass, ObjCMetaClass, NSObject,
-    objc_ivar, objc_property, objc_rawmethod, objc_method, objc_classmethod
+    objc_ivar, objc_property, objc_rawmethod, objc_method, objc_classmethod,
+    ObjCBlock
 )
 
 from .core_foundation import at, to_str, to_number, to_value, to_set, to_list

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -1652,15 +1652,51 @@ class ObjCBlockStruct(Structure):
         ('flags', c_int),
         ('reserved', c_int),
         ('invoke', CFUNCTYPE(c_void_p, c_void_p)),
+        ('descriptor', c_void_p),
     ]
+
+
+def cast_block_descriptor(block):
+    descriptor_fields = [
+        ('reserved', c_ulong),
+        ('size', c_ulong),
+    ]
+    if block.has_helpers:
+        descriptor_fields.extend([
+            ('copy_helper', CFUNCTYPE(c_void_p, c_void_p, c_void_p)),
+            ('dispose_helper', CFUNCTYPE(c_void_p, c_void_p)),
+        ])
+    if block.has_signature:
+        descriptor_fields.extend([
+            ('signature', c_char_p),
+        ])
+    descriptor_struct = type(
+        'ObjCBlockDescriptor',
+        (Structure, ),
+        {'_fields_': descriptor_fields}
+    )
+    return cast(block.struct.contents.descriptor, POINTER(descriptor_struct))
 
 
 class ObjCBlock:
     def __init__(self, instance, return_type, *arg_types):
         self.instance = instance
-        self.block = cast(self.instance.ptr, POINTER(ObjCBlockStruct))
-        self.block.contents.invoke.restype = return_type
-        self.block.contents.invoke.argtypes = arg_types
+        self.struct = cast(self.instance.ptr, POINTER(ObjCBlockStruct))
+        self.struct.contents.invoke.restype = return_type
+        self.struct.contents.invoke.argtypes = (objc_id, ) + arg_types
+        self.has_helpers = self.struct.contents.flags & (1<<25)
+        self.has_signature = self.struct.contents.flags & (1<<30)
+        self.descriptor = cast_block_descriptor(self)
+        self.signature = self.descriptor.contents.signature.decode('ascii') if self.has_signature else None
+
+    def __repr__(self):
+        representation = '<ObjCBlock@{}'.format(hex(addressof(self.instance.ptr)))
+        if self.has_helpers:
+            representation += ',has_helpers'
+        if self.has_signature:
+            representation += ',has_signature:' + self.signature
+        representation += '>'
+        return representation
 
     def __call__(self, *args):
-        return self.block.contents.invoke(self.instance.ptr, *args)
+        return self.struct.contents.invoke(self.instance.ptr, *args)

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -1682,8 +1682,8 @@ class ObjCBlock:
     def __init__(self, instance, return_type, *arg_types):
         self.instance = instance
         self.struct = cast(self.instance.ptr, POINTER(ObjCBlockStruct))
-        self.struct.contents.invoke.restype = return_type
-        self.struct.contents.invoke.argtypes = (objc_id, ) + arg_types
+        self.struct.contents.invoke.restype = ctype_for_type(return_type)
+        self.struct.contents.invoke.argtypes = (objc_id, ) + tuple(ctype_for_type(arg_type) for arg_type in arg_types)
         self.has_helpers = self.struct.contents.flags & (1<<25)
         self.has_signature = self.struct.contents.flags & (1<<30)
         self.descriptor = cast_block_descriptor(self)

--- a/tests/objc/Blocks.h
+++ b/tests/objc/Blocks.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+@interface BlockPropertyExample : NSObject
+@property (copy) int (^blockProperty)(int, int);
+@end
+
+
+@interface BlockDelegate : NSObject
+- (void)exampleMethod:(void (^)(int, int))blockArgument;
+@end
+
+@interface BlockObjectExample : NSObject
+@property int value;
+@property BlockDelegate *delegate;
+- (id)initWithDelegate:(BlockDelegate *)delegate;
+- (int)blockExample;
+@end

--- a/tests/objc/Blocks.h
+++ b/tests/objc/Blocks.h
@@ -4,9 +4,15 @@
 @property (copy) int (^blockProperty)(int, int);
 @end
 
+typedef struct
+{
+    int a;
+    int b;
+} blockStruct;
 
 @interface BlockDelegate : NSObject
 - (void)exampleMethod:(void (^)(int, int))blockArgument;
+- (int)structBlockMethod:(int (^)(blockStruct))blockArgument;
 @end
 
 @interface BlockObjectExample : NSObject
@@ -14,4 +20,10 @@
 @property BlockDelegate *delegate;
 - (id)initWithDelegate:(BlockDelegate *)delegate;
 - (int)blockExample;
+- (int)structBlockExample;
+@end
+
+
+@interface BlockReceiverExample : NSObject
+- (void)receiverMethod:(void (^)(int, int))blockArgument;
 @end

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -1,0 +1,39 @@
+#import "Blocks.h"
+
+@implementation BlockPropertyExample
+
+-(id) init
+{
+    self = [super init];
+
+    if (self) {
+        self.blockProperty = ^(int a, int b){
+            return a + b;
+        };
+    }
+    return self;
+}
+
+@end
+
+@implementation BlockObjectExample
+
+-(id) initWithDelegate:(BlockDelegate *)delegate
+{
+  self = [super init];
+  if (self) {
+    self.delegate = delegate;
+  }
+  return self;
+}
+
+-(int) blockExample {
+  BlockDelegate *delegate = self.delegate;
+  NSLog(@"Delegate is: %@", delegate);
+
+  [delegate exampleMethod:^(int a, int b){
+    self.value = a + b;
+  }];
+  return self.value;
+}
+@end

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -29,7 +29,6 @@
 
 -(int) blockExample {
     BlockDelegate *delegate = self.delegate;
-    NSLog(@"Delegate is: %@", delegate);
 
     [delegate exampleMethod:^(int a, int b){
         self.value = a + b;

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -20,20 +20,20 @@
 
 -(id) initWithDelegate:(BlockDelegate *)delegate
 {
-  self = [super init];
-  if (self) {
-    self.delegate = delegate;
-  }
-  return self;
+    self = [super init];
+    if (self) {
+        self.delegate = delegate;
+    }
+    return self;
 }
 
 -(int) blockExample {
-  BlockDelegate *delegate = self.delegate;
-  NSLog(@"Delegate is: %@", delegate);
+    BlockDelegate *delegate = self.delegate;
+    NSLog(@"Delegate is: %@", delegate);
 
-  [delegate exampleMethod:^(int a, int b){
-    self.value = a + b;
-  }];
-  return self.value;
+    [delegate exampleMethod:^(int a, int b){
+        self.value = a + b;
+    }];
+    return self.value;
 }
 @end

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -27,7 +27,8 @@
     return self;
 }
 
--(int) blockExample {
+-(int) blockExample
+{
     BlockDelegate *delegate = self.delegate;
 
     [delegate exampleMethod:^(int a, int b){
@@ -35,4 +36,21 @@
     }];
     return self.value;
 }
+
+-(int) structBlockExample
+{
+    BlockDelegate *delegate = self.delegate;
+    return [delegate structBlockMethod:^(blockStruct bs){
+        return bs.a + bs.b;
+    }];
+}
+@end
+
+@implementation BlockReceiverExample
+
+-(void) receiverMethod:(void (^)(int, int))blockArgument
+{
+    blockArgument(13, 14);
+}
+
 @end

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -23,11 +23,8 @@ from rubicon.objc import (
     send_message, ObjCBlock
 )
 from rubicon.objc import core_foundation, types
-from rubicon.objc.objc import (
-    ObjCBoundMethod, objc_block, get_signature_types,
-    objc_id,
-    Class,
-)
+from rubicon.objc.objc import ObjCBoundMethod, objc_block, objc_id, Class
+
 
 # Load the test harness library
 harnesslib = util.find_library('rubiconharness')
@@ -1198,31 +1195,6 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
 
 
 class BlockTests(unittest.TestCase):
-    def test_signature_decoding_simple(self):
-        def struct(name, *fields):
-            return type(name, (Structure,), {'_fields_': [('f%s' % index, field) for index, field in enumerate(fields)]})
-
-        table = [
-            ('{example=@*i}', [struct('example', objc_id, c_char_p, c_int)]),
-            ('cislqCISLQfdBv*@#:', [c_char, c_int, c_short, c_long, c_longlong, c_ubyte, c_uint, c_ushort, c_ulong, c_ulonglong, c_float, c_double, c_bool, c_void_p, c_char_p, objc_id, Class, SEL]),
-            ('[12i][42L]', [c_int * 12, c_ulonglong * 42]),
-            ('^[42q]', [POINTER(c_long * 42)]),
-            ('@?', [objc_block]),
-        ]
-        def eq(a, b):
-            if issubclass(a, Structure):
-                self.assertTrue(issubclass(b, Structure))
-                self.assertEqual(a.__name__, b.__name__)
-                self.assertEqual(a._fields_, b._fields_)
-            else:
-                self.assertEqual(a, b)
-
-        for signature, expected in table:
-            got = list(get_signature_types(signature))
-            with self.subTest(signature=signature, expected=expected, got=got):
-                for a, b in zip(got, expected):
-                    eq(a, b)
-
     def test_block_property_ctypes(self):
         BlockPropertyExample = ObjCClass("BlockPropertyExample")
         instance = BlockPropertyExample.alloc().init()

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -24,8 +24,7 @@ from rubicon.objc import (
     send_message, ObjCBlock
 )
 from rubicon.objc import core_foundation, types
-from rubicon.objc.objc import ObjCBoundMethod
-
+from rubicon.objc.objc import ObjCBoundMethod, objc_block
 
 # Load the test harness library
 harnesslib = util.find_library('rubiconharness')
@@ -1195,3 +1194,14 @@ class BlockTests(unittest.TestCase):
         instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
         result = instance.blockExample()
         self.assertEqual(result, 5)
+
+    def test_block_delegate_auto(self):
+        class DelegateAuto(NSObject):
+            @objc_method
+            def exampleMethod_(self, block: objc_block):
+                block(4, 5)
+        BlockObjectExample = ObjCClass("BlockObjectExample")
+        delegate = DelegateAuto.alloc().init()
+        instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
+        result = instance.blockExample()
+        self.assertEqual(result, 9)

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -1162,19 +1162,36 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
 
 
 class BlockTests(unittest.TestCase):
-    def test_block_property(self):
+    def test_block_property_ctypes(self):
         BlockPropertyExample = ObjCClass("BlockPropertyExample")
         instance = BlockPropertyExample.alloc().init()
         result = ObjCBlock(instance.blockProperty, c_int, c_int, c_int)(1, 2)
         self.assertEqual(result, 3)
 
-    def test_block_delegate_method_manual(self):
-        class DelegateManual(NSObject):
+    def test_block_property_pytypes(self):
+        BlockPropertyExample = ObjCClass("BlockPropertyExample")
+        instance = BlockPropertyExample.alloc().init()
+        result = ObjCBlock(instance.blockProperty, int, int, int)(1, 2)
+        self.assertEqual(result, 3)
+
+    def test_block_delegate_method_manual_ctypes(self):
+        class DelegateManualC(NSObject):
             @objc_method
             def exampleMethod_(self, block):
                 ObjCBlock(block, c_void_p, c_int, c_int)(2, 3)
         BlockObjectExample = ObjCClass("BlockObjectExample")
-        delegate = DelegateManual.alloc().init()
+        delegate = DelegateManualC.alloc().init()
+        instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
+        result = instance.blockExample()
+        self.assertEqual(result, 5)
+
+    def test_block_delegate_method_manual_pytypes(self):
+        class DelegateManualPY(NSObject):
+            @objc_method
+            def exampleMethod_(self, block):
+                ObjCBlock(block, None, int, int)(2, 3)
+        BlockObjectExample = ObjCClass("BlockObjectExample")
+        delegate = DelegateManualPY.alloc().init()
         instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
         result = instance.blockExample()
         self.assertEqual(result, 5)

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -21,7 +21,7 @@ from rubicon.objc import (
     NSObject, SEL,
     objc, objc_method, objc_classmethod, objc_property,
     NSUInteger, NSRange, NSEdgeInsets, NSEdgeInsetsMake,
-    send_message
+    send_message, ObjCBlock
 )
 from rubicon.objc import core_foundation, types
 from rubicon.objc.objc import ObjCBoundMethod
@@ -1160,3 +1160,21 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
         self.assertEqual(d['four'], 'FIVE')
         self.assertEqual(len(d), len(self.py_dict) + 1)
 
+
+class BlockTests(unittest.TestCase):
+    def test_block_property(self):
+        BlockPropertyExample = ObjCClass("BlockPropertyExample")
+        instance = BlockPropertyExample.alloc().init()
+        result = ObjCBlock(instance.blockProperty, c_int, c_int, c_int)(1, 2)
+        self.assertEqual(result, 3)
+
+    def test_block_delegate_method_manual(self):
+        class DelegateManual(NSObject):
+            @objc_method
+            def exampleMethod_(self, block):
+                ObjCBlock(block, c_void_p, c_int, c_int)(2, 3)
+        BlockObjectExample = ObjCClass("BlockObjectExample")
+        delegate = DelegateManual.alloc().init()
+        instance = BlockObjectExample.alloc().initWithDelegate_(delegate)
+        result = instance.blockExample()
+        self.assertEqual(result, 5)


### PR DESCRIPTION
Improved version of #50

This PR implements:

* API to manually transform an `ObjCInstance` which is an objc block to a callable object, using `ObjCBlock(objc_instance, return_type, *arg_types)(*args)`.
* API to automatically transform objc blocks given as arguments to python methods into a callable, as long as that block has a signature (and not bitfields), using the type annotation `objc_block`.

This PR does **not** implement:

* Passing Python callables as blocks to objc.