### PR TITLE
Convert Python sequences passed to methods into structures/arrays

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Added support for using native Python sequence/mapping syntax with ``NSArray`` and ``NSDictionary``. (jeamland)
 * Added functions for declaring custom conversions between Objective-C type encodings and ``ctypes`` types.
+* Added automatic conversion of Python sequences to C arrays or structures in method arguments.
 * Extended the Objective-C type encoding decoder to support block types, bit fields (in structures), typed object pointers, and arbitrary qualifiers. If unknown pointer, array, struct or union types are encountered, they are created and registered on the fly.
 * Changed the ``PyObjectEncoding`` to match the real definition of ``PyObject *``.
 * Fixed the declaration of ``unichar`` (was previously ``c_wchar``, is now ``c_ushort``).

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -1,3 +1,4 @@
+import collections.abc
 import inspect
 import os
 
@@ -693,6 +694,8 @@ class ObjCMethod(object):
                 if argtype == objc_id:
                     # Convert Python objects to Core Foundation objects
                     arg = from_value(arg)
+                elif isinstance(arg, collections.abc.Iterable) and issubclass(argtype, (Structure, Array)):
+                    arg = compound_value_for_sequence(arg, argtype)
 
                 converted_args.append(arg)
         else:

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -229,4 +229,9 @@ static int _staticIntField = 11;
     };
 }
 
++(struct simple) extractSimpleStruct:(struct complex)complex
+{
+    return complex.s;
+}
+
 @end

--- a/tests/test_rubicon.py
+++ b/tests/test_rubicon.py
@@ -501,6 +501,16 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(ret.field_5, 1)
         self.assertEqual(ret.field_6, 2)
 
+    def test_sequence_arg_to_struct(self):
+        "Sequence arguments are converted to structures."
+        Example = ObjCClass('Example')
+        
+        ret = Example.extractSimpleStruct(([9, 8, 7, 6], None, (987, 654), None, 0, 0, 0))
+        struct_simple = types.ctype_for_encoding(b'{simple=ii}')
+        self.assertIsInstance(ret, struct_simple)
+        self.assertEqual(ret.field_0, 987)
+        self.assertEqual(ret.field_1, 654)
+
     def test_struct_return(self):
         "Methods returning structs of different sizes by value can be handled."
         Example = ObjCClass('Example')


### PR DESCRIPTION
This makes passing structures into a method much shorter. For example, a `NSRect` can be written simply as `((x, y), (width, height))` instead of `NSMakeRect(x, y, width, height)` or `NSRect(NSPoint(x, y), NSSize(width, height))`:

```python
>>> NSView = objc.ObjCClass("NSView")
>>> NSView.alloc().initWithFrame_(((10, 20), (30, 40)))
<rubicon.objc.objc.ObjCInstance 0x104f10780: NSView at 0x10206ac40: <NSView: 0x10206ac40>>
>>> _.frame
<rubicon.objc.types.NSRect at 0x105387400>
>>> _.origin.x, _.origin.y, _.size.width, _.size.height
(10.0, 20.0, 30.0, 40.0)
```

This works similarly for arrays in structures.