### PR TITLE
Added support for sending blocks to objc

### DIFF
--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -5,7 +5,7 @@ from .objc import (
     SEL, objc_id, Class, IMP, Method, Ivar, objc_property_t,
     ObjCInstance, ObjCClass, ObjCMetaClass, NSObject,
     objc_ivar, objc_property, objc_rawmethod, objc_method, objc_classmethod,
-    ObjCBlock
+    ObjCBlock, Block
 )
 
 from .core_foundation import at, to_str, to_number, to_value, to_set, to_list

--- a/rubicon/objc/objc.py
+++ b/rubicon/objc/objc.py
@@ -1728,7 +1728,7 @@ class ObjCBlockInstance(ObjCInstance):
         return self.block(*args)
 
 
-_NSConcreteGlobalBlock = ObjCClass("__NSGlobalBlock__")
+_NSConcreteGlobalBlock = (c_void_p * 32).in_dll(c, "_NSConcreteGlobalBlock")
 
 
 NOTHING = object()
@@ -1767,7 +1767,7 @@ class Block:
         self.cfunc_type = CFUNCTYPE(restype, c_void_p, *signature)
 
         self.literal = BlockLiteral()
-        self.literal.isa = _NSConcreteGlobalBlock.ptr
+        self.literal.isa = addressof(_NSConcreteGlobalBlock)
         self.literal.flags = BlockConsts.HAS_STRET | BlockConsts.HAS_SIGNATURE
         self.literal.reserved = 0
         self.cfunc = self.cfunc_type(self.wrapper)
@@ -1776,7 +1776,6 @@ class Block:
         self.descriptor.reserved = 0
         self.descriptor.size = sizeof(BlockLiteral)
 
-        encoding_for_ctype(restype)
         self.descriptor.signature = encoding_for_ctype(restype) + b'@?' + b''.join(
             encoding_for_ctype(arg) for arg in signature
         )

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -20,6 +20,9 @@ __arm64__ = (_any_arm and __LP64__)
 __arm__ = (_any_arm and not __LP64__)
 
 
+POINTER_TYPE = type(POINTER(c_void_p))
+
+
 _ctype_for_type_map = {
     int: c_int,
     float: c_double,
@@ -235,7 +238,8 @@ def ctype_for_encoding(encoding):
 
 def encoding_for_ctype(ctype):
     """Return the Objective-C type encoding for the given ctypes type."""
-    
+    if isinstance(ctype, POINTER_TYPE):
+        return b'^' + encoding_for_ctype(ctype._type_)
     try:
         return _encoding_for_ctype_map[ctype]
     except KeyError:

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -20,9 +20,6 @@ __arm64__ = (_any_arm and __LP64__)
 __arm__ = (_any_arm and not __LP64__)
 
 
-POINTER_TYPE = type(POINTER(c_void_p))
-
-
 _ctype_for_type_map = {
     int: c_int,
     float: c_double,
@@ -238,12 +235,13 @@ def ctype_for_encoding(encoding):
 
 def encoding_for_ctype(ctype):
     """Return the Objective-C type encoding for the given ctypes type."""
-    if isinstance(ctype, POINTER_TYPE):
-        return b'^' + encoding_for_ctype(ctype._type_)
     try:
         return _encoding_for_ctype_map[ctype]
     except KeyError:
-        raise ValueError('No type encoding known for ctype {}'.format(ctype))
+        try:
+            return b'^' + encoding_for_ctype(ctype._type_)
+        except KeyError:
+            raise ValueError('No type encoding known for ctype {}'.format(ctype))
 
 def register_preferred_encoding(encoding, ctype):
     """Register a preferred conversion between an Objective-C type encoding and a ctypes type.

--- a/tests/objc/Blocks.h
+++ b/tests/objc/Blocks.h
@@ -27,3 +27,8 @@ typedef struct
 @interface BlockReceiverExample : NSObject
 - (void)receiverMethod:(void (^)(int, int))blockArgument;
 @end
+
+
+@interface BlockRoundTrip : NSObject
+- (int (^)(int, int))roundTrip:(int (^)(int, int))blockArgument;
+@end

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -54,3 +54,12 @@
 }
 
 @end
+
+@implementation BlockRoundTrip
+
+- (int (^)(int, int)) roundTrip:(int (^)(int, int))blockArgument
+{
+    return blockArgument;
+}
+
+@end


### PR DESCRIPTION
This adds support for sending blocks to objc. It supports both "automagical python callable to objc block style" (which in non-trivial cases can segfault due to python GC) as well as "explicit create a block object style" through the `rubicon.objc.Block`. 

Magical style (functions need to be fully annotated):

```python

def myblock(arg1: arg1type, arg2: arg2type) -> return_type:
    ...

objc_instance.ObjcMethod_(myblock)
```

Explicit style:

```python
from rubicon.objc import Block

myblock = Block(lambda a, b: ..., return_type, argtype1, argtype2)
objc_instance.ObjcMethod_(myblock)
```