### PR TITLE
Fix Objective-C properties in tests on i386

### DIFF
--- a/tests/objc/Blocks.h
+++ b/tests/objc/Blocks.h
@@ -1,6 +1,9 @@
 #import <Foundation/Foundation.h>
 
-@interface BlockPropertyExample : NSObject
+@interface BlockPropertyExample : NSObject {
+    int (^_blockProperty)(int, int);
+}
+
 @property (copy) int (^blockProperty)(int, int);
 @end
 
@@ -15,9 +18,13 @@ typedef struct
 - (int)structBlockMethod:(int (^)(blockStruct))blockArgument;
 @end
 
-@interface BlockObjectExample : NSObject
+@interface BlockObjectExample : NSObject {
+    int _value;
+    BlockDelegate *_delegate;
+}
+
 @property int value;
-@property BlockDelegate *delegate;
+@property (retain) BlockDelegate *delegate;
 - (id)initWithDelegate:(BlockDelegate *)delegate;
 - (int)blockExample;
 - (int)structBlockExample;

--- a/tests/objc/Blocks.m
+++ b/tests/objc/Blocks.m
@@ -2,6 +2,8 @@
 
 @implementation BlockPropertyExample
 
+@synthesize blockProperty = _blockProperty;
+
 -(id) init
 {
     self = [super init];
@@ -17,6 +19,9 @@
 @end
 
 @implementation BlockObjectExample
+
+@synthesize value = _value;
+@synthesize delegate = _delegate;
 
 -(id) initWithDelegate:(BlockDelegate *)delegate
 {

--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -43,7 +43,7 @@ struct large {
 }
 
 #if __has_extension(objc_class_property)
-@property (class) int classAmbiguous;
+@property (class, readonly) int classAmbiguous;
 #endif
 
 @property int intField;


### PR DESCRIPTION
Because i386 uses the old ABI, properties aren't synthesized automatically and have some different defaults than with the current ABI. This caused compiler warnings and/or crashes in a few cases.