### PR TITLE
Update and shorten .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,18 @@
+os: osx
 matrix:
   include:
-    # OSX 10.10 Yosemite
-    - os: osx
-      osx_image: xcode6.4
-      language: generic
-    # OSX 10.11 El Capitan
-    - os: osx
-      osx_image: xcode7.3.1
-      language: generic
-    - os: osx
-      osx_image: xcode8
-      language: generic
-    # macOS 10.12 Sierra
-    - os: osx
-      osx_image: xcode8.3
-      language: generic
+  # OSX 10.10 Yosemite
+  - osx_image: xcode6.4
+  # OSX 10.11 El Capitan
+  - osx_image: xcode7.3
+  - osx_image: xcode8
+  # macOS 10.12 Sierra
+  - osx_image: xcode8.3
+  - osx_image: xcode9
+language: generic
 install:
-  - brew install python3
-  - make -f Makefile
+- brew install python3
+- make -f Makefile
 script:
-  - export DYLD_LIBRARY_PATH=`pwd`/tests/objc
-  - python3 setup.py test
+- export DYLD_LIBRARY_PATH=`pwd`/tests/objc
+- python3 setup.py test


### PR DESCRIPTION
This adds an Xcode 9 test environment, and shortens the `matrix` section by not repeating the parts that are always the same.