### PR TITLE
Fix a few obscure issues with ObjCDictInstance

### DIFF
--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1365,7 +1365,7 @@ class ObjCDictInstance(ObjCInstance):
             yield key, self.objectForKey_(key)
 
     def copy(self):
-        return self.objc_class.dictionaryWithDictionary_(self)
+        return ObjCClass('NSMutableDictionary').dictionaryWithDictionary_(self)
 
 
 class ObjCMutableDictInstance(ObjCDictInstance):

--- a/tests/test_NSDictionary.py
+++ b/tests/test_NSDictionary.py
@@ -79,9 +79,6 @@ class NSDictionaryMixinTest(unittest.TestCase):
         self.assertEqual(e, d)
         self.assertEqual(e, self.py_dict)
 
-        with self.assertRaises(TypeError):
-            e['four'] = 'FOUR'
-
     def test_keys(self):
         a = self.make_dictionary(self.py_dict)
         for k1, k2 in zip(sorted(a.keys()), sorted(self.py_dict.keys())):


### PR DESCRIPTION
See the commit messages for detailed explanations.

These issues only became apparent when trying to run the test suite on OS X 10.7. On current OS X versions, the code just happened to work, even though it was not strictly correct.