### PR TITLE
Remove F403 (star imports) from flake8 ignore list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,12 +10,11 @@ exclude=*.egg-info/*,.git/*,.tox/*,__pycache__,build/*,docs/*
 max-complexity = 20
 max-line-length = 119
 
-# Currently ignored:
-# E133: closing bracket missing indentation  # does not match code style
-# E226: missing whitespace around arithmetic operator  # does not match code style
-# F403: 'from module import *' used; unable to detect undefined names  # currently used almost everywhere
-# W503: line break occurred before a binary operator  # does not match code style
-ignore = E133,E226,F403,W503
+# The following issues are ignored because they do not match our code style:
+# E133: closing bracket missing indentation
+# E226: missing whitespace around arithmetic operator
+# W503: line break occurred before a binary operator
+ignore = E133,E226,W503
 
 [isort]
 combine_as_imports = true


### PR DESCRIPTION
There are no more star imports in the code, they were all replaced with explicit `from`-`import`s, and I apparently overlooked that.