### PR TITLE
Fixed #1 -- Allow returning structures by copy.

### DIFF
--- a/rubicon/objc/async.py
+++ b/rubicon/objc/async.py
@@ -1,18 +1,17 @@
 """PEP 3156 event loop based on CoreFoundation"""
 
+import threading
 from asyncio import (
-    DefaultEventLoopPolicy, coroutines, events, tasks, unix_events
+    DefaultEventLoopPolicy, coroutines, events, tasks, unix_events,
 )
 from ctypes import CFUNCTYPE, POINTER, Structure, c_int, c_void_p
-import threading
 
 from .core_foundation import (
-    CFAbsoluteTime, CFAllocatorRef, CFDataRef, CFOptionFlags,
-    CFStringRef, CFTimeInterval, kCFAllocatorDefault, libcf
+    CFAbsoluteTime, CFAllocatorRef, CFDataRef, CFOptionFlags, CFStringRef,
+    CFTimeInterval, kCFAllocatorDefault, libcf,
 )
 from .runtime import objc_const, objc_id
 from .types import CFIndex
-
 
 __all__ = [
     'EventLoopPolicy',

--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -44,6 +44,7 @@ extern NSString *const SomeGlobalStringConstant;
     NSDictionary *_dict;
     id<Callback> _callback;
     int _ambiguous;
+
 }
 
 #if __has_extension(objc_class_property)
@@ -110,5 +111,7 @@ extern NSString *const SomeGlobalStringConstant;
 
 -(id) processDictionary:(NSDictionary *) dict;
 -(id) processArray:(NSArray *) dict;
+
+-(NSSize) testThing:(int) value;
 
 @end

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -254,4 +254,12 @@ static int _staticIntField = 11;
     return [array objectAtIndex:1];
 }
 
+-(NSSize) testThing:(int) value
+{
+    printf("VALUE: %d\n", value);
+    NSSize size = [_thing computeSize:NSMakeSize(0, value)];
+    printf("SIZE: %f %f\n", size.width, size.height);
+    return size;
+}
+
 @end

--- a/tests/objc/Thing.h
+++ b/tests/objc/Thing.h
@@ -11,4 +11,6 @@
 
 -(NSString *) toString;
 
+-(NSSize) computeSize: (NSSize) input;
+
 @end

--- a/tests/objc/Thing.m
+++ b/tests/objc/Thing.m
@@ -29,4 +29,10 @@
     return self.name;
 }
 
+-(NSSize) computeSize: (NSSize) input
+{
+    printf("THING COMPUTE %f %f\n", input.width, input.height);
+    return NSMakeSize(input.width * 2, input.height * 3);
+}
+
 @end


### PR DESCRIPTION
This workaround essentially treats "return structure by copy" as a Python object pointer - which means it's treated like a block of memory; but the Structure subclasses know how to interpret that block of memory, so it seems to work.

It all seems a little *too* easy... so i'm wondering what I've missed...