### PR TITLE
Fixed #1 -- Allow returning structs by value from methods

### DIFF
--- a/rubicon/objc/ctypes_patch.py
+++ b/rubicon/objc/ctypes_patch.py
@@ -1,0 +1,146 @@
+"""This module provides a workaround to allow callback functions to return composite types (most importantly structs).
+
+Currently, ctypes callback functions (created by passing a Python callable to a CFUNCTYPE object) are only able to return what ctypes considers a "simple" type. This includes void (None), scalars (c_int, c_float, etc.), c_void_p, c_char_p, c_wchar_p, and py_object. Returning "composite" types (structs, unions, and non-"simple" pointers) is not possible. This issue has been reported on the Python bug tracker as bpo-5710 (https://bugs.python.org/issue5710).
+
+For pointers, the easiest workaround is to return a c_void_p instead of the correctly typed pointer, and to cast the value on both sides. For structs and unions there is no easy workaround, which is why this somewhat hacky workaround is necessary.
+"""
+
+import ctypes
+import sys
+import warnings
+
+# This module relies on the layout of a few internal Python and ctypes structures.
+# Because of this, it's possible (but not all that likely) that things will break on newer/older Python versions.
+if sys.version_info < (3, 4) or sys.version_info >= (3, 7):
+    warnings.warn(
+        "rubicon.objc.ctypes_patch has only been tested with Python 3.4 through 3.6. "
+        "The current version is {}. Most likely things will work properly, "
+        "but you may experience crashes if Python's internals have changed significantly."
+        .format(sys.version_info)
+    )
+
+# The PyTypeObject struct from "Include/object.h".
+# This is a forward declaration, fields are set later once PyVarObject has been declared.
+class PyTypeObject(ctypes.Structure):
+    pass
+
+# The PyObject struct from "Include/object.h".
+class PyObject(ctypes.Structure):
+    _fields_ = [
+        ("ob_refcnt", ctypes.c_ssize_t),
+        ("ob_type", ctypes.POINTER(PyTypeObject)),
+    ]
+
+# The PyVarObject struct from "Include/object.h".
+class PyVarObject(ctypes.Structure):
+    _fields_ = [
+        ("ob_base", PyObject),
+        ("ob_size", ctypes.c_ssize_t),
+    ]
+
+# This structure is not stable across Python versions, but the few fields that we use probably won't change.
+PyTypeObject._fields_ = [
+    ("ob_base", PyVarObject),
+    ("tp_name", ctypes.c_char_p),
+    ("tp_basicsize", ctypes.c_ssize_t),
+    ("tp_itemsize", ctypes.c_ssize_t),
+    # There are many more fields, but we're only interested in the size fields, so we can leave out everything else.
+]
+
+# The PyTypeObject structure for the dict class.
+# This is used to determine the size of the PyDictObject structure.
+PyDict_Type = PyTypeObject.from_address(id(dict))
+
+# The PyDictObject structure from "Include/dictobject.h".
+# This structure is not stable across Python versions, and did indeed change in recent Python releases.
+# Because we only care about the size of the structure and not its actual contents,
+# we can declare it as an opaque byte array, with the length taken from PyDict_Type.
+class PyDictObject(ctypes.Structure):
+    _fields_ = [
+        ("PyDictObject_opaque", (ctypes.c_ubyte*PyDict_Type.tp_basicsize)),
+    ]
+
+# The ffi_type structure from libffi's "include/ffi.h".
+# This is a forward declaration, because the structure contains pointers to itself.
+class ffi_type(ctypes.Structure):
+    pass
+
+ffi_type._fields_ = [
+    ("size", ctypes.c_size_t),
+    ("alignment", ctypes.c_ushort),
+    ("type", ctypes.c_ushort),
+    ("elements", ctypes.POINTER(ctypes.POINTER(ffi_type))),
+]
+
+# The GETFUNC and SETFUNC typedefs from "Modules/_ctypes/ctypes.h".
+GETFUNC = ctypes.PYFUNCTYPE(ctypes.py_object, ctypes.c_void_p, ctypes.c_ssize_t)
+SETFUNC = ctypes.PYFUNCTYPE(ctypes.py_object, ctypes.c_void_p, ctypes.py_object, ctypes.c_ssize_t)
+
+# The StgDictObject structure from "Modules/_ctypes/ctypes.h".
+# This structure is not officially stable across Python versions,
+# but it basically hasn't changed since ctypes was originally added to Python in 2009.
+class StgDictObject(ctypes.Structure):
+    _fields_ = [
+        ("dict", PyDictObject),
+        ("size", ctypes.c_ssize_t),
+        ("align", ctypes.c_ssize_t),
+        ("length", ctypes.c_ssize_t),
+        ("ffi_type_pointer", ffi_type),
+        ("proto", ctypes.py_object),
+        ("setfunc", SETFUNC),
+        ("getfunc", GETFUNC),
+        # There are a few more fields, but we leave them out again because we don't need them.
+    ]
+
+# The PyObject_stgdict function from "Modules/_ctypes/ctypes.h".
+ctypes.pythonapi.PyType_stgdict.restype = ctypes.POINTER(StgDictObject)
+ctypes.pythonapi.PyType_stgdict.argtypes = [ctypes.py_object]
+
+def make_callback_returnable(ctype):
+    """Modify the given ctypes type so it can be returned from a callback function.
+    
+    This function may be used as a decorator on a struct/union declaration.
+    """
+
+    # Extract the StgDict from the ctype.
+    stgdict_c = ctypes.pythonapi.PyType_stgdict(ctype).contents
+
+    # Ensure that there is no existing getfunc or setfunc on the stgdict.
+    if ctypes.cast(stgdict_c.getfunc, ctypes.c_void_p).value is not None:
+        raise ValueError("The ctype {} already has a getfunc")
+    elif ctypes.cast(stgdict_c.setfunc, ctypes.c_void_p).value is not None:
+        raise ValueError("The ctype {} already has a setfunc")
+
+    # Define the getfunc and setfunc.
+    @GETFUNC
+    def getfunc(ptr, size):
+        actual_size = ctypes.sizeof(ctype)
+        if size != 0 and size != actual_size:
+            raise ValueError(
+                "getfunc for ctype {}: Requested size {} does not match actual size {}"
+                .format(ctype, size, actual_size)
+            )
+
+        return ctype.from_buffer_copy(ctypes.string_at(ptr, actual_size))
+
+    @SETFUNC
+    def setfunc(ptr, value, size):
+        actual_size = ctypes.sizeof(ctype)
+        if size != 0 and size != actual_size:
+            raise ValueError(
+                "setfunc for ctype {}: Requested size {} does not match actual size {}"
+                .format(ctype, size, actual_size)
+            )
+
+        ctypes.memmove(ptr, ctypes.addressof(value), actual_size)
+        return None
+
+    # Store the getfunc and setfunc as attributes on the ctype, so they don't get garbage-collected.
+    ctype._rubicon_objc_ctypes_patch_getfunc = getfunc
+    ctype._rubicon_objc_ctypes_patch_setfunc = setfunc
+    # Put the getfunc and setfunc into the stgdict fields.
+    stgdict_c.getfunc = getfunc
+    stgdict_c.setfunc = setfunc
+
+    # Return the passed in ctype, so this function can be used as a decorator.
+    return ctype

--- a/tests/objc/Example.h
+++ b/tests/objc/Example.h
@@ -111,4 +111,6 @@ extern NSString *const SomeGlobalStringConstant;
 -(id) processDictionary:(NSDictionary *) dict;
 -(id) processArray:(NSArray *) dict;
 
+-(NSSize) testThing:(int) value;
+
 @end

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -256,10 +256,7 @@ static int _staticIntField = 11;
 
 -(NSSize) testThing:(int) value
 {
-    printf("VALUE: %d\n", value);
-    NSSize size = [_thing computeSize:NSMakeSize(0, value)];
-    printf("SIZE: %f %f\n", size.width, size.height);
-    return size;
+    return [_thing computeSize:NSMakeSize(0, value)];
 }
 
 @end

--- a/tests/objc/Example.m
+++ b/tests/objc/Example.m
@@ -254,4 +254,12 @@ static int _staticIntField = 11;
     return [array objectAtIndex:1];
 }
 
+-(NSSize) testThing:(int) value
+{
+    printf("VALUE: %d\n", value);
+    NSSize size = [_thing computeSize:NSMakeSize(0, value)];
+    printf("SIZE: %f %f\n", size.width, size.height);
+    return size;
+}
+
 @end

--- a/tests/objc/Thing.h
+++ b/tests/objc/Thing.h
@@ -11,4 +11,6 @@
 
 -(NSString *) toString;
 
+-(NSSize) computeSize: (NSSize) input;
+
 @end

--- a/tests/objc/Thing.m
+++ b/tests/objc/Thing.m
@@ -31,7 +31,6 @@
 
 -(NSSize) computeSize: (NSSize) input
 {
-    printf("THING COMPUTE %f %f\n", input.width, input.height);
     return NSMakeSize(input.width * 2, input.height * 3);
 }
 

--- a/tests/objc/Thing.m
+++ b/tests/objc/Thing.m
@@ -29,4 +29,10 @@
     return self.name;
 }
 
+-(NSSize) computeSize: (NSSize) input
+{
+    printf("THING COMPUTE %f %f\n", input.width, input.height);
+    return NSMakeSize(input.width * 2, input.height * 3);
+}
+
 @end

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -999,15 +999,8 @@ class RubiconTest(unittest.TestCase):
             @objc_method
             def computeSize_(self, input: NSSize) -> NSSize:
                 results['size'] = True
-                print("INPUT", input.width, input.height)
                 sup = send_super(self, 'computeSize:', input, restype=NSSize, argtypes=[NSSize])
-                print("SUPER", sup.width, sup.height)
-                output = NSSize(
-                    input.width + self.value,
-                    sup.height
-                )
-                print("COMPUTED OUTPUT", output.width, output.height)
-                return output
+                return NSSize(input.width + self.value, sup.height)
 
             @objc_method
             def computeRect_(self, input: NSRect) -> NSRect:
@@ -1046,7 +1039,6 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(outSize.height, 30)
 
         # Test the python handler
-        print('-'*40)
         obj.thing = handler1
         outSize = obj.testThing(15)
         self.assertEqual(outSize.width, 5)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1046,7 +1046,7 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(outSize.height, 30)
 
         # Test the python handler
-        print('-'* 40)
+        print('-'*40)
         obj.thing = handler1
         outSize = obj.testThing(15)
         self.assertEqual(outSize.width, 5)


### PR DESCRIPTION
Fixes #1. The test case copied over from #84 runs for me locally, so maybe this version actually works.

I looked through the `ctypes` source code to find out why exactly struct types were not accepted as callback return types. Here's the gist of it:

* `ctypes` types have a custom `__dict__` of type `StgDict`. The only difference between regular `dict` and `StgDict` is that `StgDict` provides a bunch of extra fields on the C side. This is used by the `ctypes` internals to look up certain information more quickly.
* The `StgDict` structure has a field called `setfunc`. It's a C function pointer that is used to copy a `ctypes` object's data into a `void *`. The `setfunc` field is only set on "simple" types, i. e. scalars. On compound types it is `NULL`.
* When a ctype is used as the return type for a callback, the callback creation code looks up the `setfunc` field of the ctype's `StgDict`. When it sees that the `setfunc` is `NULL`, it errors out. This is why only "simple" types are accepted.
* As a "fix", I wrote a function `make_callback_returnable`, which takes a ctype and adds the missing `setfunc` at runtime. This now allows it to be used as a callback return value.

The custom `setfunc` is a very simple implementation, it just `memmove`s the struct data from the `ctypes` object into the return buffer. If the struct "owns" other `ctypes` objects, they are lost after the callback returns. I think this is okay, because it's the same issue that you have in C when you try to return local data from a function call. Usually this won't even matter - often the returned struct is a pure value struct like `NSRect` that contains no pointers.

Again, if there are any questions, or if there's a part that I forgot to explain, please tell me.