### PR TITLE
Fixes for return-by-copy for larger structures

### DIFF
--- a/rubicon/objc/async.py
+++ b/rubicon/objc/async.py
@@ -1,18 +1,17 @@
 """PEP 3156 event loop based on CoreFoundation"""
 
+import threading
 from asyncio import (
-    DefaultEventLoopPolicy, coroutines, events, tasks, unix_events
+    DefaultEventLoopPolicy, coroutines, events, tasks, unix_events,
 )
 from ctypes import CFUNCTYPE, POINTER, Structure, c_int, c_void_p
-import threading
 
 from .core_foundation import (
-    CFAbsoluteTime, CFAllocatorRef, CFDataRef, CFOptionFlags,
-    CFStringRef, CFTimeInterval, kCFAllocatorDefault, libcf
+    CFAbsoluteTime, CFAllocatorRef, CFDataRef, CFOptionFlags, CFStringRef,
+    CFTimeInterval, kCFAllocatorDefault, libcf,
 )
 from .runtime import objc_const, objc_id
 from .types import CFIndex
-
 
 __all__ = [
     'EventLoopPolicy',

--- a/rubicon/objc/ctypes_patch.py
+++ b/rubicon/objc/ctypes_patch.py
@@ -125,9 +125,9 @@ def make_callback_returnable(ctype):
 
     # Ensure that there is no existing getfunc or setfunc on the stgdict.
     if ctypes.cast(stgdict_c.getfunc, ctypes.c_void_p).value is not None:
-        raise ValueError("The ctype {} already has a getfunc")
+        raise ValueError("The ctype {}.{} already has a getfunc".format(ctype.__module__, ctype.__name__))
     elif ctypes.cast(stgdict_c.setfunc, ctypes.c_void_p).value is not None:
-        raise ValueError("The ctype {} already has a setfunc")
+        raise ValueError("The ctype {}.{} already has a setfunc".format(ctype.__module__, ctype.__name__))
 
     # Define the getfunc and setfunc.
     @GETFUNC

--- a/rubicon/objc/ctypes_patch.py
+++ b/rubicon/objc/ctypes_patch.py
@@ -14,7 +14,6 @@ import ctypes
 import sys
 import warnings
 
-
 # This module relies on the layout of a few internal Python and ctypes structures.
 # Because of this, it's possible (but not all that likely) that things will break on newer/older Python versions.
 if sys.version_info < (3, 4) or sys.version_info >= (3, 7):

--- a/rubicon/objc/ctypes_patch.py
+++ b/rubicon/objc/ctypes_patch.py
@@ -118,7 +118,14 @@ def make_callback_returnable(ctype):
     """Modify the given ctypes type so it can be returned from a callback function.
 
     This function may be used as a decorator on a struct/union declaration.
+
+    The method is idempotent; it only modifies the type the first time it
+    is invoked on a type.
     """
+    # The presence of the _rubicon_objc_ctypes_patch_getfunc attribute is a
+    # sentinel for whether the type has been modified previously.
+    if hasattr(ctype, '_rubicon_objc_ctypes_patch_getfunc'):
+        return ctype
 
     # Extract the StgDict from the ctype.
     stgdict_c = ctypes.pythonapi.PyType_stgdict(ctype).contents

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -715,10 +715,6 @@ def add_method(cls, selName, method, encoding):
     signature = [ctype_for_type(tp) for tp in encoding]
     assert signature[1] == objc_id  # ensure id self typecode
     assert signature[2] == SEL  # ensure SEL cmd typecode
-    if signature[0] is not None and issubclass(signature[0], (Structure, Union)):
-        # Patch struct/union return types to make them work in callbacks.
-        # See the source code of the ctypes_patch module for details.
-        ctypes_patch.make_callback_returnable(signature[0])
     selector = SEL(selName)
     types = b"".join(encoding_for_ctype(ctype) for ctype in signature)
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -2,10 +2,10 @@ import collections.abc
 import inspect
 import os
 from ctypes import (
-    CDLL, CFUNCTYPE, POINTER, ArgumentError, Array, Structure, Union, addressof,
-    alignment, byref, c_bool, c_char_p, c_double, c_float, c_int, c_int32,
-    c_int64, c_longdouble, c_size_t, c_uint, c_uint8, c_ulong, c_void_p, cast,
-    sizeof, util,
+    CDLL, CFUNCTYPE, POINTER, ArgumentError, Array, Structure, Union,
+    addressof, alignment, byref, c_bool, c_char_p, c_double, c_float, c_int,
+    c_int32, c_int64, c_longdouble, c_size_t, c_uint, c_uint8, c_ulong,
+    c_void_p, cast, sizeof, util,
 )
 from enum import Enum
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -718,6 +718,10 @@ def add_method(cls, selName, method, encoding):
     signature = [ctype_for_type(tp) for tp in encoding]
     assert signature[1] == objc_id  # ensure id self typecode
     assert signature[2] == SEL  # ensure SEL cmd typecode
+    if signature[0] is not None and issubclass(signature[0], (Structure, Union)):
+        # Patch struct/union return types to make them work in callbacks.
+        # See the source code of the ctypes_patch module for details.
+        ctypes_patch.make_callback_returnable(signature[0])
     selector = SEL(selName)
     types = b"".join(encoding_for_ctype(ctype) for ctype in signature)
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -673,12 +673,15 @@ def send_super(receiver, selName, *args, **kwargs):
     restype = kwargs.get('restype', c_void_p)
     argtypes = kwargs.get('argtypes', None)
 
-    send = libobjc['objc_msgSendSuper']
-    send.restype = restype
-    if argtypes:
-        send.argtypes = [POINTER(objc_super), SEL] + argtypes
+    if should_use_stret(restype):
+        send = libobjc['objc_msgSendSuper_stret']
     else:
-        send.argtypes = None
+        send = libobjc['objc_msgSendSuper']
+    send.restype = restype
+    if argtypes is None:
+        send.argtypes = [POINTER(objc_super), SEL]
+    else:
+        send.argtypes = [POINTER(objc_super), SEL] + argtypes
     result = send(byref(super_struct), selector, *args)
     if restype == c_void_p:
         result = c_void_p(result)

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -7,7 +7,6 @@ from ctypes import (
     c_ubyte, c_uint, c_ulong, c_ulonglong, c_ushort, c_void_p, c_wchar,
     c_wchar_p, py_object, sizeof,
 )
-from .ctypes_patch import make_callback_returnable
 
 __all__ = [
     'CFIndex',
@@ -614,7 +613,6 @@ class UnknownPointer(c_void_p):
     """
 
 # from /System/Library/Frameworks/Foundation.framework/Headers/NSGeometry.h
-@make_callback_returnable
 @with_preferred_encoding(_NSPointEncoding)
 class NSPoint(Structure):
     _fields_ = [
@@ -626,7 +624,6 @@ class NSPoint(Structure):
 CGPoint = NSPoint
 
 
-@make_callback_returnable
 @with_preferred_encoding(_NSSizeEncoding)
 class NSSize(Structure):
     _fields_ = [
@@ -638,7 +635,6 @@ class NSSize(Structure):
 CGSize = NSSize
 
 
-@make_callback_returnable
 @with_preferred_encoding(_NSRectEncoding)
 class NSRect(Structure):
     _fields_ = [
@@ -672,7 +668,6 @@ CGPointMake = NSMakePoint
 
 
 # iOS: /System/Library/Frameworks/UIKit.framework/Headers/UIGeometry.h
-@make_callback_returnable
 @with_preferred_encoding(_UIEdgeInsetsEncoding)
 class UIEdgeInsets(Structure):
     _fields_ = [('top', CGFloat),
@@ -689,7 +684,6 @@ UIEdgeInsetsZero = UIEdgeInsets(0, 0, 0, 0)
 
 
 # macOS: /System/Library/Frameworks/AppKit.framework/Headers/NSLayoutConstraint.h
-@make_callback_returnable
 @with_preferred_encoding(_NSEdgeInsetsEncoding)
 class NSEdgeInsets(Structure):
     _fields_ = [('top', CGFloat),
@@ -715,7 +709,6 @@ CGGlyph = c_ushort
 
 # CFRange struct defined in CFBase.h
 # This replaces the CFRangeMake(LOC, LEN) macro.
-@make_callback_returnable
 class CFRange(Structure):
     _fields_ = [
         ("location", CFIndex),
@@ -724,7 +717,6 @@ class CFRange(Structure):
 
 
 # NSRange.h  (Note, not defined the same as CFRange)
-@make_callback_returnable
 @with_preferred_encoding(_NSRangeEncoding)
 class NSRange(Structure):
     _fields_ = [

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -612,6 +612,7 @@ class UnknownPointer(c_void_p):
     to it.
     """
 
+
 # from /System/Library/Frameworks/Foundation.framework/Headers/NSGeometry.h
 @with_preferred_encoding(_NSPointEncoding)
 class NSPoint(Structure):

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -7,6 +7,7 @@ from ctypes import (
     c_ubyte, c_uint, c_ulong, c_ulonglong, c_ushort, c_void_p, c_wchar,
     c_wchar_p, py_object, sizeof,
 )
+from .ctypes_patch import make_callback_returnable
 
 __all__ = [
     'CFIndex',
@@ -612,8 +613,8 @@ class UnknownPointer(c_void_p):
     to it.
     """
 
-
 # from /System/Library/Frameworks/Foundation.framework/Headers/NSGeometry.h
+@make_callback_returnable
 @with_preferred_encoding(_NSPointEncoding)
 class NSPoint(Structure):
     _fields_ = [
@@ -625,6 +626,7 @@ class NSPoint(Structure):
 CGPoint = NSPoint
 
 
+@make_callback_returnable
 @with_preferred_encoding(_NSSizeEncoding)
 class NSSize(Structure):
     _fields_ = [
@@ -636,6 +638,7 @@ class NSSize(Structure):
 CGSize = NSSize
 
 
+@make_callback_returnable
 @with_preferred_encoding(_NSRectEncoding)
 class NSRect(Structure):
     _fields_ = [
@@ -669,6 +672,7 @@ CGPointMake = NSMakePoint
 
 
 # iOS: /System/Library/Frameworks/UIKit.framework/Headers/UIGeometry.h
+@make_callback_returnable
 @with_preferred_encoding(_UIEdgeInsetsEncoding)
 class UIEdgeInsets(Structure):
     _fields_ = [('top', CGFloat),
@@ -685,6 +689,7 @@ UIEdgeInsetsZero = UIEdgeInsets(0, 0, 0, 0)
 
 
 # macOS: /System/Library/Frameworks/AppKit.framework/Headers/NSLayoutConstraint.h
+@make_callback_returnable
 @with_preferred_encoding(_NSEdgeInsetsEncoding)
 class NSEdgeInsets(Structure):
     _fields_ = [('top', CGFloat),
@@ -710,6 +715,7 @@ CGGlyph = c_ushort
 
 # CFRange struct defined in CFBase.h
 # This replaces the CFRangeMake(LOC, LEN) macro.
+@make_callback_returnable
 class CFRange(Structure):
     _fields_ = [
         ("location", CFIndex),
@@ -718,6 +724,7 @@ class CFRange(Structure):
 
 
 # NSRange.h  (Note, not defined the same as CFRange)
+@make_callback_returnable
 @with_preferred_encoding(_NSRangeEncoding)
 class NSRange(Structure):
     _fields_ = [

--- a/tests/objc/Thing.h
+++ b/tests/objc/Thing.h
@@ -12,5 +12,6 @@
 -(NSString *) toString;
 
 -(NSSize) computeSize: (NSSize) input;
+-(NSRect) computeRect: (NSRect) input;
 
 @end

--- a/tests/objc/Thing.m
+++ b/tests/objc/Thing.m
@@ -34,4 +34,10 @@
     return NSMakeSize(input.width * 2, input.height * 3);
 }
 
+-(NSRect) computeRect: (NSRect) input
+{
+    return NSMakeRect(input.origin.x + 100, input.origin.y + 200, input.size.width * 2, input.size.height * 3);
+}
+
+
 @end

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1005,10 +1005,17 @@ class RubiconTest(unittest.TestCase):
             @objc_method
             def computeRect_(self, input: NSRect) -> NSRect:
                 results['rect'] = True
+                sup = send_super(self, 'computeRect:', input, restype=NSRect, argtypes=[NSRect])
                 return NSMakeRect(
-                    input.origin.y + self.value, input.origin.x,
-                    input.size.height + self.value, input.size.width
+                    input.origin.y + self.value, sup.origin.x,
+                    input.size.height + self.value, sup.size.width
                 )
+
+            # Register a second method returning NSSize. Don't
+            # have to use it - just have to register that it exists.
+            @objc_method
+            def origin(self) -> NSSize:
+                return NSPoint(0, 0)
 
         # Create two handler instances so we can check the right one
         # is being invoked.
@@ -1022,9 +1029,9 @@ class RubiconTest(unittest.TestCase):
 
         outRect = handler2.computeRect(NSMakeRect(10, 20, 30, 40))
         self.assertEqual(outRect.origin.x, 30)
-        self.assertEqual(outRect.origin.y, 10)
+        self.assertEqual(outRect.origin.y, 110)
         self.assertEqual(outRect.size.width, 50)
-        self.assertEqual(outRect.size.height, 30)
+        self.assertEqual(outRect.size.height, 60)
         self.assertTrue(results.get('rect'))
 
         # Invoke a method through an interface.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,9 +11,10 @@ from enum import Enum
 
 from rubicon.objc import (
     SEL, NSEdgeInsets, NSEdgeInsetsMake, NSMakeRect, NSObject,
-    NSObjectProtocol, NSRange, NSRect, NSSize, NSUInteger,
-    ObjCClass, ObjCInstance, ObjCMetaClass, ObjCProtocol, core_foundation, objc_classmethod,
-    objc_const, objc_method, objc_property, send_message, send_super, types,
+    NSObjectProtocol, NSRange, NSRect, NSSize, NSUInteger, ObjCClass,
+    ObjCInstance, ObjCMetaClass, ObjCProtocol, core_foundation,
+    objc_classmethod, objc_const, objc_method, objc_property, send_message,
+    send_super, types,
 )
 from rubicon.objc.runtime import ObjCBoundMethod, libobjc
 
@@ -1015,7 +1016,7 @@ class RubiconTest(unittest.TestCase):
             # have to use it - just have to register that it exists.
             @objc_method
             def origin(self) -> NSSize:
-                return NSPoint(0, 0)
+                return NSSize(0, 0)
 
         # Create two handler instances so we can check the right one
         # is being invoked.


### PR DESCRIPTION
Three features here:

* Clarify the error message when structures have already been registered
* Require pre-registration of structures that will be returned, rather than on-demand. The on-demand approach fails as soon as you have 2 methods returning the same structure (even if they're on different classes)
* Use the -stret variant of `objc_msgSendSuper` when returning a structure. For some reason, the non-stret version works fine for NSPoint and NSSize, but fails on NSRect.