### PR TITLE
Remove deprecated Xcode 8.0 OS X image from Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
     - osx_image: xcode6.4
     # OSX 10.11 El Capitan
     - osx_image: xcode7.3
-    - osx_image: xcode8
     # macOS 10.12 Sierra
     - osx_image: xcode8.3
     - osx_image: xcode9.1


### PR DESCRIPTION
See https://blog.travis-ci.com/2017-11-21-xcode8-3-default-image-announce#retiring-some-older-images.