### PR TITLE
Rewrite most of the core_foundation module based on Foundation

### DIFF
--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -1,14 +1,10 @@
 __version__ = '0.2.9'
 
-from .core_foundation import (  # noqa: F401
-    NSArray, NSDictionary, NSMutableArray, NSMutableDictionary, at, to_list,
-    to_number, to_set, to_str, to_value,
-)
 from .runtime import (  # noqa: F401
-    IMP, SEL, Block, Class, Ivar, Method, NSObject, NSObjectProtocol, ObjCBlock, ObjCClass,
-    ObjCInstance, ObjCMetaClass, ObjCProtocol, objc_classmethod, objc_const, objc_id,
-    objc_ivar, objc_method, objc_property, objc_property_t, objc_rawmethod,
-    send_message, send_super,
+    IMP, SEL, Block, Class, Ivar, Method, NSArray, NSDictionary, NSMutableArray, NSMutableDictionary, NSObject,
+    NSObjectProtocol, ObjCBlock, ObjCClass, ObjCInstance, ObjCMetaClass, ObjCProtocol, at, ns_from_py,
+    objc_classmethod, objc_const, objc_id, objc_ivar, objc_method, objc_property, objc_property_t, objc_rawmethod,
+    py_from_ns, send_message, send_super,
 )
 from .types import (  # noqa: F401
     CFIndex, CFRange, CGFloat, CGGlyph, CGPoint, CGPointMake, CGRect,

--- a/rubicon/objc/core_foundation.py
+++ b/rubicon/objc/core_foundation.py
@@ -37,7 +37,6 @@ __all__ = [
     'NSDecimalNumber',
     'at',
     'from_value',
-    'is_str',
     'kCFAllocatorDefault',
     'kCFNumberCFIndexType',
     'kCFNumberCGFloatType',
@@ -152,10 +151,6 @@ def to_str(cfstring):
     result = libcf.CFStringGetCString(cfstring, buffer, len(buffer), kCFStringEncodingUTF8)
     if result:
         return buffer.value.decode('utf-8')
-
-
-def is_str(cfobject):
-    return libcf.CFGetTypeID(cfobject) == libcf.CFStringGetTypeID()
 
 
 libcf.CFDataCreate.restype = CFDataRef

--- a/rubicon/objc/core_foundation.py
+++ b/rubicon/objc/core_foundation.py
@@ -1,68 +1,21 @@
-from ctypes import (
-    CFUNCTYPE, POINTER, byref, c_bool, c_buffer, c_byte, c_char_p, c_double,
-    c_float, c_int, c_int8, c_int16, c_int32, c_int64, c_long, c_longlong,
-    c_short, c_uint8, c_uint32, c_ulong, c_void_p, cast, cdll, util,
-)
-from decimal import Decimal
-from enum import Enum
+from ctypes import c_double, c_ulong, cdll
+from ctypes.util import find_library
 
-from .runtime import (
-    SEL, ObjCClass, ObjCInstance, get_class, libobjc, objc_id, send_message,
-)
-from .types import CFIndex, CFRange, CGFloat
+from .runtime import objc_id
 
 __all__ = [
     'CFAbsoluteTime',
     'CFAllocatorRef',
-    'CFArrayRef',
-    'CFAttributedStringRef',
-    'CFData',
     'CFDataRef',
-    'CFDictionaryRef',
-    'CFMutableArrayRef',
-    'CFMutableDictionaryRef',
-    'CFMutableSetRef',
-    'CFNumberRef',
-    'CFNumberType',
     'CFOptionFlags',
     'CFRunLoopRef',
-    'CFSTR',
-    'CFSetRef',
-    'CFStringEncoding',
     'CFStringRef',
     'CFTimeInterval',
     'CFTypeID',
     'CFTypeRef',
-    'NSDecimalNumber',
-    'at',
-    'from_value',
     'kCFAllocatorDefault',
-    'kCFNumberCFIndexType',
-    'kCFNumberCGFloatType',
-    'kCFNumberCharType',
-    'kCFNumberDoubleType',
-    'kCFNumberFloat32Type',
-    'kCFNumberFloat64Type',
-    'kCFNumberFloatType',
-    'kCFNumberIntType',
-    'kCFNumberLongLongType',
-    'kCFNumberLongType',
-    'kCFNumberMaxType',
-    'kCFNumberNSIntegerType',
-    'kCFNumberSInt16Type',
-    'kCFNumberSInt32Type',
-    'kCFNumberSInt64Type',
-    'kCFNumberSInt8Type',
-    'kCFNumberShortType',
     'kCFRunLoopDefaultMode',
-    'kCFStringEncodingUTF8',
     'libcf',
-    'to_bool',
-    'to_list',
-    'to_number',
-    'to_set',
-    'to_str',
-    'to_value',
 ]
 
 
@@ -70,7 +23,7 @@ __all__ = [
 
 # CORE FOUNDATION
 
-libcf = cdll.LoadLibrary(util.find_library('CoreFoundation'))
+libcf = cdll.LoadLibrary(find_library('CoreFoundation'))
 
 CFTypeID = c_ulong
 
@@ -81,300 +34,13 @@ CFTypeRef = objc_id
 CFAllocatorRef = objc_id
 kCFAllocatorDefault = None
 
-CFArrayRef = objc_id
-CFAttributedStringRef = objc_id
-CFData = objc_id
 CFDataRef = objc_id
-CFDictionaryRef = objc_id
-CFMutableArrayRef = objc_id
-CFMutableDictionaryRef = objc_id
-CFMutableSetRef = objc_id
-CFNumberRef = objc_id
 CFOptionFlags = c_ulong
 CFRunLoopRef = objc_id
-CFSetRef = objc_id
 CFStringRef = objc_id
-
-CFStringEncoding = c_uint32
-kCFStringEncodingUTF8 = 0x08000100
 
 CFTimeInterval = c_double
 CFAbsoluteTime = CFTimeInterval
-
-libcf.CFGetTypeID.restype = CFTypeID
-libcf.CFGetTypeID.argtypes = [CFTypeRef]
-
-libcf.CFRelease.restype = None
-libcf.CFRelease.argtypes = [CFTypeRef]
-
-libcf.CFStringCreateWithCString.restype = CFStringRef
-libcf.CFStringCreateWithCString.argtypes = [CFAllocatorRef, c_char_p, CFStringEncoding]
-
-libcf.CFStringGetLength.restype = CFIndex
-libcf.CFStringGetLength.argtypes = [CFStringRef]
-
-libcf.CFStringGetMaximumSizeForEncoding.restype = CFIndex
-libcf.CFStringGetMaximumSizeForEncoding.argtypes = [CFIndex, CFStringEncoding]
-
-libcf.CFStringGetCString.restype = c_bool
-libcf.CFStringGetCString.argtypes = [CFStringRef, c_char_p, CFIndex, CFStringEncoding]
-
-libcf.CFStringGetTypeID.restype = CFTypeID
-libcf.CFStringGetTypeID.argtypes = []
-
-libcf.CFAttributedStringCreate.restype = CFAttributedStringRef
-libcf.CFAttributedStringCreate.argtypes = [CFAllocatorRef, CFStringRef, CFDictionaryRef]
-
-
-# Core Foundation type to Python type conversion functions
-def CFSTR(string):
-    return ObjCInstance(libcf.CFStringCreateWithCString(
-        None, string.encode('utf-8'), kCFStringEncodingUTF8,
-    ))
-
-
-# Other possible names for this method:
-# ampersat, arobe, apenstaartje (little monkey tail), strudel,
-# Klammeraffe (spider monkey), little_mouse, arroba, sobachka (doggie)
-# malpa (monkey), snabel (trunk), papaki (small duck), afna (monkey),
-# kukac (caterpillar).
-def at(string):
-    """Autoreleased version of CFSTR"""
-    return ObjCInstance(send_message(CFSTR(string), 'autorelease'))
-
-
-def to_str(cfstring):
-    length = libcf.CFStringGetLength(cfstring)
-    size = libcf.CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8)
-    buffer = c_buffer(size + 1)
-    result = libcf.CFStringGetCString(cfstring, buffer, len(buffer), kCFStringEncodingUTF8)
-    if result:
-        return buffer.value.decode('utf-8')
-
-
-libcf.CFDataCreate.restype = CFDataRef
-libcf.CFDataCreate.argtypes = [CFAllocatorRef, POINTER(c_uint8), CFIndex]
-
-libcf.CFDataGetBytes.restype = None
-libcf.CFDataGetBytes.argtypes = [CFDataRef, CFRange, POINTER(c_uint8)]
-
-libcf.CFDataGetLength.restype = CFIndex
-libcf.CFDataGetLength.argtypes = [CFDataRef]
-
-libcf.CFDictionaryGetValue.restype = c_void_p
-libcf.CFDictionaryGetValue.argtypes = [CFDictionaryRef, c_void_p]
-
-libcf.CFDictionaryCreateMutable.restype = c_void_p
-libcf.CFDictionaryCreateMutable.argtypes = [CFAllocatorRef, CFIndex, c_void_p, c_void_p]
-
-libcf.CFDictionaryAddValue.restype = None
-libcf.CFDictionaryAddValue.argtypes = [CFMutableDictionaryRef, c_void_p, c_void_p]
-
-# CFNumber.h
-CFNumberType = c_uint32
-kCFNumberSInt8Type = 1
-kCFNumberSInt16Type = 2
-kCFNumberSInt32Type = 3
-kCFNumberSInt64Type = 4
-kCFNumberFloat32Type = 5
-kCFNumberFloat64Type = 6
-kCFNumberCharType = 7
-kCFNumberShortType = 8
-kCFNumberIntType = 9
-kCFNumberLongType = 10
-kCFNumberLongLongType = 11
-kCFNumberFloatType = 12
-kCFNumberDoubleType = 13
-kCFNumberCFIndexType = 14
-kCFNumberNSIntegerType = 15
-kCFNumberCGFloatType = 16
-kCFNumberMaxType = 16
-
-libcf.CFNumberCreate.restype = CFNumberRef
-libcf.CFNumberCreate.argtypes = [CFAllocatorRef, CFNumberType, c_void_p]
-
-libcf.CFNumberGetType.restype = CFNumberType
-libcf.CFNumberGetType.argtypes = [CFNumberRef]
-
-libcf.CFNumberGetValue.restype = c_bool
-libcf.CFNumberGetValue.argtypes = [CFNumberRef, CFNumberType, c_void_p]
-
-libcf.CFNumberGetTypeID.restype = CFTypeID
-libcf.CFNumberGetTypeID.argtypes = []
-
-
-def to_number(cfnumber):
-    """Convert CFNumber to python int or float."""
-    if type(cfnumber) == objc_id:
-        cfnumber = ObjCInstance(cfnumber)
-
-    numeric_type = libcf.CFNumberGetType(cfnumber)
-    cfnum_to_ctype = {
-        kCFNumberSInt8Type: c_int8,
-        kCFNumberSInt16Type: c_int16,
-        kCFNumberSInt32Type: c_int32,
-        kCFNumberSInt64Type: c_int64,
-        kCFNumberFloat32Type: c_float,
-        kCFNumberFloat64Type: c_double,
-        kCFNumberCharType: c_byte,
-        kCFNumberShortType: c_short,
-        kCFNumberIntType: c_int,
-        kCFNumberLongType: c_long,
-        kCFNumberLongLongType: c_longlong,
-        kCFNumberFloatType: c_float,
-        kCFNumberDoubleType: c_double,
-        kCFNumberCFIndexType: CFIndex,
-        kCFNumberCGFloatType: CGFloat
-    }
-
-    # NSDecimalNumber reports as a double. So does an NSNumber of type double.
-    # In the case of NSDecimalNumber, convert to a Python decimal.
-    if numeric_type == kCFNumberDoubleType and cfnumber.objc_class.name == 'NSDecimalNumber':
-        return Decimal(cfnumber.stringValue)
-
-    # Otherwise, just do the conversion.
-    try:
-        t = cfnum_to_ctype[numeric_type]
-        result = t()
-        if libcf.CFNumberGetValue(cfnumber, numeric_type, byref(result)):
-            return result.value
-    except KeyError:
-        raise Exception('to_number: unhandled CFNumber type %d' % numeric_type)
-
-
-def to_bool(cfbool):
-    """Convert CFBoolean to python bool."""
-    if type(cfbool) == objc_id:
-        cfbool = ObjCInstance(cfbool)
-
-    return bool(libcf.CFBooleanGetValue(cfbool))
-
-
-# We need to be able to create raw NSDecimalNumber objects; if we use an
-# normal ObjCClass() wrapper, the return values of constructors will be
-# auto-converted back into Python Decimals. However, we want to cache
-# class/selector/method lookups so that we don't have the overhead
-# every time we use a decimal.
-class NSDecimalNumber(object):
-    objc_class = None
-
-    @classmethod
-    def from_decimal(cls, value):
-        if cls.objc_class is None:
-            cls.objc_class = get_class('NSDecimalNumber')
-            cls.selector = SEL('decimalNumberWithString:')
-            method = libobjc.class_getClassMethod(cls.objc_class, cls.selector)
-            impl = libobjc.method_getImplementation(method)
-            cls.constructor = cast(impl, CFUNCTYPE(objc_id, objc_id, SEL, objc_id))
-
-        return ObjCInstance(cls.constructor(cast(cls.objc_class, objc_id), cls.selector, at(value.to_eng_string())))
-
-
-NSArray = ObjCClass('NSArray')
-NSMutableArray = ObjCClass('NSMutableArray')
-
-NSDictionary = ObjCClass('NSDictionary')
-NSMutableDictionary = ObjCClass('NSMutableDictionary')
-
-NSNumber = ObjCClass('NSNumber')
-
-
-def from_value(value):
-    """Convert a Python type into an equivalent CFType type.
-    """
-    if isinstance(value, Enum):
-        value = value.value
-
-    if isinstance(value, str):
-        return at(value)
-    elif isinstance(value, bytes):
-        return at(value.decode('utf-8'))
-    elif isinstance(value, Decimal):
-        return NSDecimalNumber.from_decimal(value)
-    elif isinstance(value, dict):
-        dikt = NSMutableDictionary.alloc().init()
-        for k, v in value.items():
-            dikt.setObject_forKey_(v, k)
-        return dikt
-    elif isinstance(value, list):
-        array = NSMutableArray.alloc().init()
-        for v in value:
-            array.addObject(v)
-        return array
-    # Need to use raw message passing here to make sure Rubicon doesn't
-    # convert the NSNumber back into Python objects.
-    elif isinstance(value, bool):
-        return cast(send_message(NSNumber, 'numberWithBool:', value), objc_id)
-    elif isinstance(value, int):
-        return cast(send_message(NSNumber, 'numberWithLong:', value), objc_id)
-    elif isinstance(value, float):
-        return cast(send_message(NSNumber, 'numberWithDouble:', value), objc_id)
-    else:
-        return value
-
-
-# Dictionary of cftypes matched to the method converting them to python values.
-known_cftypes = {
-    libcf.CFStringGetTypeID(): to_str,
-    libcf.CFNumberGetTypeID(): to_number,
-    libcf.CFBooleanGetTypeID(): to_bool,
-}
-
-
-def to_value(cftype):
-    """Convert a CFType into an equivalent python type.
-    The convertible CFTypes are taken from the known_cftypes
-    dictionary, which may be added to if another library implements
-    its own conversion methods."""
-    # Don't use simple boolean testing here since that can trigger a len()
-    # check which will cause NS{,Mutable}{Array,Dict} to explode.
-    if cftype is None:
-        return None
-    if isinstance(cftype, ObjCInstance):
-        cftype = cftype._as_parameter_
-    typeID = libcf.CFGetTypeID(cftype)
-    try:
-        convert_function = known_cftypes[typeID]
-        ret = convert_function(cftype)
-    except KeyError:
-        ret = cftype
-
-    if isinstance(ret, objc_id):
-        return ObjCInstance(ret)
-    else:
-        return ret
-
-
-libcf.CFSetGetCount.restype = CFIndex
-libcf.CFSetGetCount.argtypes = [CFSetRef]
-
-libcf.CFSetGetValues.restype = None
-libcf.CFSetGetValues.argtypes = [CFSetRef, POINTER(c_void_p)]
-
-
-def to_set(cfset):
-    """Convert CFSet to python set."""
-    count = libcf.CFSetGetCount(cfset)
-    buffer = (c_void_p * count)()
-    libcf.CFSetGetValues(cfset, buffer)
-    return {to_value(cast(buffer[i], objc_id)) for i in range(count)}
-
-
-libcf.CFArrayGetCount.restype = CFIndex
-libcf.CFArrayGetCount.argtypes = [CFArrayRef]
-
-libcf.CFArrayGetValueAtIndex.restype = c_void_p
-libcf.CFArrayGetValueAtIndex.argtypes = [CFArrayRef, CFIndex]
-
-
-def to_list(cfarray):
-    """Convert CFArray to python list."""
-    count = libcf.CFArrayGetCount(cfarray)
-    return [
-        to_value(cast(libcf.CFArrayGetValueAtIndex(cfarray, i), objc_id))
-        for i in range(count)
-    ]
-
 
 kCFRunLoopDefaultMode = CFStringRef.in_dll(libcf, 'kCFRunLoopDefaultMode')
 

--- a/rubicon/objc/core_foundation.py
+++ b/rubicon/objc/core_foundation.py
@@ -7,8 +7,7 @@ from decimal import Decimal
 from enum import Enum
 
 from .runtime import (
-    SEL, Class, ObjCClass, ObjCInstance, get_class, libobjc, objc_id,
-    send_message,
+    SEL, ObjCClass, ObjCInstance, get_class, libobjc, objc_id, send_message,
 )
 from .types import CFIndex, CFRange, CGFloat
 
@@ -340,10 +339,8 @@ def to_value(cftype):
     except KeyError:
         ret = cftype
 
-    if type(ret) == objc_id:
+    if isinstance(ret, objc_id):
         return ObjCInstance(ret)
-    elif type(ret) == Class:
-        return ObjCClass(ret)
     else:
         return ret
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1726,6 +1726,7 @@ def py_from_ns(nsobj, *, _auto=False):
         # conversions (strings and numbers).
         return nsobj
     elif nsobj.isKindOfClass(NSData):
+        # Despite the name, string_at converts the data at the address to a bytes object, not str.
         return string_at(send_message(nsobj, 'bytes', restype=POINTER(c_uint8), argtypes=[]), nsobj.length)
     elif nsobj.isKindOfClass(NSDictionary):
         return {py_from_ns(k): py_from_ns(v) for k, v in nsobj.items()}

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1309,9 +1309,8 @@ class ObjCInstance(object):
         return self
 
     def __str__(self):
-        from . import core_foundation
-        if core_foundation.is_str(self):
-            return core_foundation.to_str(self)
+        if isinstance(self, NSString):
+            return self.UTF8String.decode('utf-8')
         else:
             desc = self.description
             if desc is None:
@@ -1661,6 +1660,10 @@ register_ctype_for_type(ObjCClass, Class)
 
 
 NSObject = ObjCClass('NSObject')
+NSObject.declare_property('debugDescription')
+NSObject.declare_property('description')
+NSString = ObjCClass('NSString')
+NSString.declare_property('UTF8String')
 NSArray = ObjCClass('NSArray')
 NSMutableArray = ObjCClass('NSMutableArray')
 NSDictionary = ObjCClass('NSDictionary')

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -947,9 +947,18 @@ def cache_property_methods(cls, name):
         # Check 3: Is there a setName: method to set the property with the given name
         mutator = cache_method(cls, 'set' + name[0].title() + name[1:] + ':')
 
+        # Check 4: Is this a forced property on this class or a superclass?
+        forced = False
+        superclass = cls
+        while superclass is not None:
+            if name in superclass.forced_properties:
+                forced = True
+                break
+            superclass = superclass.superclass
+
         # If the class responds as a property, or it has both an accessor *and*
         # and mutator, then treat it as a property in Python.
-        if responds or (accessor and mutator) or (name in cls.forced_properties):
+        if responds or (accessor and mutator) or forced:
             methods = (accessor, mutator)
         else:
             methods = None

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -898,7 +898,8 @@ class ObjCBoundMethod(object):
             self.receiver = receiver
 
     def __repr__(self):
-        return '<ObjCBoundMethod %s (%s)>' % (self.method.name, self.receiver)
+        return '{cls.__module__}.{cls.__qualname__}({self.method}, {self.receiver})'.format(
+            cls=type(self), self=self)
 
     def __call__(self, *args, **kwargs):
         """Call the method with the given arguments."""

--- a/rubicon/objc/types.py
+++ b/rubicon/objc/types.py
@@ -581,9 +581,9 @@ if __LP64__:
     NSInteger = c_long
     NSUInteger = c_ulong
     CGFloat = c_double
-    _NSPointEncoding = b'{CGPoint=dd}'
-    _NSSizeEncoding = b'{CGSize=dd}'
-    _NSRectEncoding = b'{CGRect={CGPoint=dd}{CGSize=dd}}'
+    _NSPointEncoding = _CGPointEncoding = b'{CGPoint=dd}'
+    _NSSizeEncoding = _CGSizeEncoding = b'{CGSize=dd}'
+    _NSRectEncoding = _CGRectEncoding = b'{CGRect={CGPoint=dd}{CGSize=dd}}'
     _NSRangeEncoding = b'{_NSRange=QQ}'
     _UIEdgeInsetsEncoding = b'{UIEdgeInsets=dddd}'
     _NSEdgeInsetsEncoding = b'{NSEdgeInsets=dddd}'
@@ -592,9 +592,12 @@ else:
     NSInteger = c_int
     NSUInteger = c_uint
     CGFloat = c_float
-    _NSPointEncoding = b'{CGPoint=ff}'
-    _NSSizeEncoding = b'{CGSize=ff}'
-    _NSRectEncoding = b'{CGRect={CGPoint=ff}{CGSize=ff}}'
+    _NSPointEncoding = b'{_NSPoint=ff}'
+    _CGPointEncoding = b'{CGPoint=ff}'
+    _NSSizeEncoding = b'{_NSSize=ff}'
+    _CGSizeEncoding = b'{CGSize=ff}'
+    _NSRectEncoding = b'{_NSRect={_NSPoint=ff}{_NSSize=ff}}'
+    _CGRectEncoding = b'{CGRect={CGPoint=ff}{CGSize=ff}}'
     _NSRangeEncoding = b'{_NSRange=II}'
     _UIEdgeInsetsEncoding = b'{UIEdgeInsets=ffff}'
     _NSEdgeInsetsEncoding = b'{NSEdgeInsets=ffff}'
@@ -622,7 +625,15 @@ class NSPoint(Structure):
     ]
 
 
-CGPoint = NSPoint
+if _CGPointEncoding == _NSPointEncoding:
+    CGPoint = NSPoint
+else:
+    @with_preferred_encoding(_CGPointEncoding)
+    class CGPoint(Structure):
+        _fields_ = [
+            ("x", CGFloat),
+            ("y", CGFloat)
+        ]
 
 
 @with_preferred_encoding(_NSSizeEncoding)
@@ -633,7 +644,15 @@ class NSSize(Structure):
     ]
 
 
-CGSize = NSSize
+if _CGSizeEncoding == _NSSizeEncoding:
+    CGSize = NSSize
+else:
+    @with_preferred_encoding(_CGSizeEncoding)
+    class CGSize(Structure):
+        _fields_ = [
+            ("width", CGFloat),
+            ("height", CGFloat)
+        ]
 
 
 @with_preferred_encoding(_NSRectEncoding)
@@ -644,28 +663,39 @@ class NSRect(Structure):
     ]
 
 
-CGRect = NSRect
+if _CGRectEncoding == _NSRectEncoding:
+    CGRect = NSRect
+else:
+    @with_preferred_encoding(_CGRectEncoding)
+    class CGRect(Structure):
+        _fields_ = [
+            ("origin", CGPoint),
+            ("size", CGSize)
+        ]
 
 
 def NSMakeSize(w, h):
     return NSSize(w, h)
 
 
-CGSizeMake = NSMakeSize
+def CGSizeMake(w, h):
+    return CGSize(w, h)
 
 
 def NSMakeRect(x, y, w, h):
     return NSRect(NSPoint(x, y), NSSize(w, h))
 
 
-CGRectMake = NSMakeRect
+def CGRectMake(x, y, w, h):
+    return CGRect(CGPoint(x, y), CGSize(w, h))
 
 
 def NSMakePoint(x, y):
     return NSPoint(x, y)
 
 
-CGPointMake = NSMakePoint
+def CGPointMake(x, y):
+    return CGPoint(x, y)
 
 
 # iOS: /System/Library/Frameworks/UIKit.framework/Headers/UIGeometry.h

--- a/tests/test_NSArray.py
+++ b/tests/test_NSArray.py
@@ -118,7 +118,7 @@ class NSArrayMixinTest(unittest.TestCase):
         example.array = a
 
         self.assertEqual(example.array, self.py_list)
-        self.assertTrue(isinstance(example.array, ObjCListInstance))
+        self.assertIsInstance(example.array, ObjCListInstance)
         self.assertEqual(example.array[1], 'two')
 
 
@@ -269,17 +269,17 @@ class PythonObjectTest(unittest.TestCase):
 
         obj1 = PrimitiveListAttrContainer.alloc().init()
         self.assertEqual(obj1.data, [1, 2, 3])
-        self.assertTrue(isinstance(obj1.data, list))
+        self.assertIsInstance(obj1.data, list)
 
         # If it's set through a method call, it becomes an objc instance
         obj2 = PrimitiveListAttrContainer.alloc().initWithList_([4, 5, 6])
         self.assertEqual(obj2.data, [4, 5, 6])
-        self.assertTrue(isinstance(obj2.data, ObjCListInstance))
+        self.assertIsInstance(obj2.data, ObjCListInstance)
 
         # If it's set by direct attribute access, it becomes a Python object.
         obj2.data = [7, 8, 9]
         self.assertEqual(obj2.data, [7, 8, 9])
-        self.assertTrue(isinstance(obj2.data, list))
+        self.assertIsInstance(obj2.data, list)
 
     def test_primitive_list_property(self):
         class PrimitiveListContainer(NSObject):
@@ -297,15 +297,15 @@ class PythonObjectTest(unittest.TestCase):
 
         obj1 = PrimitiveListContainer.alloc().init()
         self.assertEqual(obj1.data, [1, 2, 3])
-        self.assertTrue(isinstance(obj1.data, ObjCListInstance))
+        self.assertIsInstance(obj1.data, ObjCListInstance)
 
         obj2 = PrimitiveListContainer.alloc().initWithList_([4, 5, 6])
         self.assertEqual(obj2.data, [4, 5, 6])
-        self.assertTrue(isinstance(obj2.data, ObjCListInstance))
+        self.assertIsInstance(obj2.data, ObjCListInstance)
 
         obj2.data = [7, 8, 9]
         self.assertEqual(obj2.data, [7, 8, 9])
-        self.assertTrue(isinstance(obj2.data, ObjCListInstance))
+        self.assertIsInstance(obj2.data, ObjCListInstance)
 
     def test_object_list_attribute(self):
         class ObjectListAttrContainer(NSObject):
@@ -321,17 +321,17 @@ class PythonObjectTest(unittest.TestCase):
 
         obj1 = ObjectListAttrContainer.alloc().init()
         self.assertEqual(obj1.data, ['x1', 'y2', 'z3'])
-        self.assertTrue(isinstance(obj1.data, list))
+        self.assertIsInstance(obj1.data, list)
 
         # If it's set through a method call, it becomes an objc instance
         obj2 = ObjectListAttrContainer.alloc().initWithList_(['a4', 'b5', 'c6'])
         self.assertEqual(obj2.data, ['a4', 'b5', 'c6'])
-        self.assertTrue(isinstance(obj2.data, ObjCListInstance))
+        self.assertIsInstance(obj2.data, ObjCListInstance)
 
         # If it's set by direct attribute access, it becomes a Python object.
         obj2.data = ['i7', 'j8', 'k9']
         self.assertEqual(obj2.data, ['i7', 'j8', 'k9'])
-        self.assertTrue(isinstance(obj2.data, list))
+        self.assertIsInstance(obj2.data, list)
 
     def test_object_list_property(self):
         class ObjectListContainer(NSObject):
@@ -349,15 +349,15 @@ class PythonObjectTest(unittest.TestCase):
 
         obj1 = ObjectListContainer.alloc().init()
         self.assertEqual(obj1.data, ['x1', 'y2', 'z3'])
-        self.assertTrue(isinstance(obj1.data, ObjCListInstance))
+        self.assertIsInstance(obj1.data, ObjCListInstance)
 
         obj2 = ObjectListContainer.alloc().initWithList_(['a4', 'b5', 'c6'])
         self.assertEqual(obj2.data, ['a4', 'b5', 'c6'])
-        self.assertTrue(isinstance(obj2.data, ObjCListInstance))
+        self.assertIsInstance(obj2.data, ObjCListInstance)
 
         obj2.data = ['i7', 'j8', 'k9']
         self.assertEqual(obj2.data, ['i7', 'j8', 'k9'])
-        self.assertTrue(isinstance(obj2.data, ObjCListInstance))
+        self.assertIsInstance(obj2.data, ObjCListInstance)
 
     def test_multitype_list_property(self):
         class MultitypeListContainer(NSObject):
@@ -371,4 +371,4 @@ class PythonObjectTest(unittest.TestCase):
 
         obj.data = [4, True, 'Hello', example]
         self.assertEqual(obj.data, [4, True, 'Hello', example])
-        self.assertTrue(isinstance(obj.data, ObjCListInstance))
+        self.assertIsInstance(obj.data, ObjCListInstance)

--- a/tests/test_NSDictionary.py
+++ b/tests/test_NSDictionary.py
@@ -123,7 +123,7 @@ class NSDictionaryMixinTest(unittest.TestCase):
         example.dict = d
 
         self.assertEqual(example.dict, self.py_dict)
-        self.assertTrue(isinstance(example.dict, ObjCDictInstance))
+        self.assertIsInstance(example.dict, ObjCDictInstance)
         self.assertEqual(example.dict['one'], 'ONE')
 
 
@@ -268,17 +268,17 @@ class PythonObjectTest(unittest.TestCase):
 
         obj1 = PrimitiveDictAttrContainer.alloc().init()
         self.assertEqual(obj1.data, {1: 2, 2: 4, 3: 6})
-        self.assertTrue(isinstance(obj1.data, dict))
+        self.assertIsInstance(obj1.data, dict)
 
         # If it's set through a method call, it becomes an objc instance
         obj2 = PrimitiveDictAttrContainer.alloc().initWithDict_({4: 8, 5: 10, 6: 12})
         self.assertEqual(obj2.data, {4: 8, 5: 10, 6: 12})
-        self.assertTrue(isinstance(obj2.data, ObjCDictInstance))
+        self.assertIsInstance(obj2.data, ObjCDictInstance)
 
         # If it's set by direct attribute access, it becomes a Python object.
         obj2.data = {7: 14, 8: 16, 9: 18}
         self.assertEqual(obj2.data, {7: 14, 8: 16, 9: 18})
-        self.assertTrue(isinstance(obj2.data, dict))
+        self.assertIsInstance(obj2.data, dict)
 
     def test_primitive_dict_property(self):
         class PrimitiveDictContainer(NSObject):
@@ -296,15 +296,15 @@ class PythonObjectTest(unittest.TestCase):
 
         obj1 = PrimitiveDictContainer.alloc().init()
         self.assertEqual(obj1.data, {1: 2, 2: 4, 3: 6})
-        self.assertTrue(isinstance(obj1.data, ObjCDictInstance))
+        self.assertIsInstance(obj1.data, ObjCDictInstance)
 
         obj2 = PrimitiveDictContainer.alloc().initWithDict_({4: 8, 5: 10, 6: 12})
         self.assertEqual(obj2.data, {4: 8, 5: 10, 6: 12})
-        self.assertTrue(isinstance(obj2.data, ObjCDictInstance))
+        self.assertIsInstance(obj2.data, ObjCDictInstance)
 
         obj2.data = {7: 14, 8: 16, 9: 18}
         self.assertEqual(obj2.data, {7: 14, 8: 16, 9: 18})
-        self.assertTrue(isinstance(obj2.data, ObjCDictInstance))
+        self.assertIsInstance(obj2.data, ObjCDictInstance)
 
     def test_object_dict_attribute(self):
         class ObjectDictAttrContainer(NSObject):
@@ -320,17 +320,17 @@ class PythonObjectTest(unittest.TestCase):
 
         obj1 = ObjectDictAttrContainer.alloc().init()
         self.assertEqual(obj1.data, {'x': 'x1', 'y': 'y2', 'z': 'z3'})
-        self.assertTrue(isinstance(obj1.data, dict))
+        self.assertIsInstance(obj1.data, dict)
 
         # If it's set through a method call, it becomes an objc instance
         obj2 = ObjectDictAttrContainer.alloc().initWithDict_({'a': 'a4', 'b': 'b5', 'c': 'c6'})
         self.assertEqual(obj2.data, {'a': 'a4', 'b': 'b5', 'c': 'c6'})
-        self.assertTrue(isinstance(obj2.data, ObjCDictInstance))
+        self.assertIsInstance(obj2.data, ObjCDictInstance)
 
         # If it's set by direct attribute access, it becomes a Python object.
         obj2.data = {'i': 'i7', 'j': 'j8', 'k': 'k9'}
         self.assertEqual(obj2.data, {'i': 'i7', 'j': 'j8', 'k': 'k9'})
-        self.assertTrue(isinstance(obj2.data, dict))
+        self.assertIsInstance(obj2.data, dict)
 
     def test_object_dict_property(self):
         class ObjectDictContainer(NSObject):
@@ -348,15 +348,15 @@ class PythonObjectTest(unittest.TestCase):
 
         obj1 = ObjectDictContainer.alloc().init()
         self.assertEqual(obj1.data, {'x': 'x1', 'y': 'y2', 'z': 'z3'})
-        self.assertTrue(isinstance(obj1.data, ObjCDictInstance))
+        self.assertIsInstance(obj1.data, ObjCDictInstance)
 
         obj2 = ObjectDictContainer.alloc().initWithDict_({'a': 'a4', 'b': 'b5', 'c': 'c6'})
         self.assertEqual(obj2.data, {'a': 'a4', 'b': 'b5', 'c': 'c6'})
-        self.assertTrue(isinstance(obj2.data, ObjCDictInstance))
+        self.assertIsInstance(obj2.data, ObjCDictInstance)
 
         obj2.data = {'i': 'i7', 'j': 'j8', 'k': 'k9'}
         self.assertEqual(obj2.data, {'i': 'i7', 'j': 'j8', 'k': 'k9'})
-        self.assertTrue(isinstance(obj2.data, ObjCDictInstance))
+        self.assertIsInstance(obj2.data, ObjCDictInstance)
 
     def test_multitype_dict_property(self):
         class MultitypeDictContainer(NSObject):
@@ -366,4 +366,4 @@ class PythonObjectTest(unittest.TestCase):
         obj = MultitypeDictContainer.alloc().init()
         obj.data = {4: 16, True: False, 'Hello': 'Goodbye'}
         self.assertEqual(obj.data, {4: 16, True: False, 'Hello': 'Goodbye'})
-        self.assertTrue(isinstance(obj.data, ObjCDictInstance))
+        self.assertIsInstance(obj.data, ObjCDictInstance)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,7 +12,7 @@ from enum import Enum
 from rubicon.objc import (
     SEL, NSEdgeInsets, NSEdgeInsetsMake, NSMakeRect, NSObject,
     NSObjectProtocol, NSRange, NSRect, NSSize, NSUInteger, ObjCClass,
-    ObjCInstance, ObjCMetaClass, ObjCProtocol, core_foundation,
+    ObjCInstance, ObjCMetaClass, ObjCProtocol, at,
     objc_classmethod, objc_const, objc_method, objc_property, send_message,
     send_super, types,
 )
@@ -239,8 +239,8 @@ class RubiconTest(unittest.TestCase):
         NSString = ObjCClass('NSString')
 
         self.assertIsInstance(NSObject.new(), NSObject)
-        self.assertIsInstance(core_foundation.at(''), NSString)
-        self.assertIsInstance(core_foundation.at(''), NSObject)
+        self.assertIsInstance(at(''), NSString)
+        self.assertIsInstance(at(''), NSObject)
         self.assertIsInstance(NSObject, NSObject)
         self.assertIsInstance(NSObject, NSObject.objc_class)
 
@@ -277,8 +277,8 @@ class RubiconTest(unittest.TestCase):
         NSCoding = ObjCProtocol('NSCoding')
         NSSecureCoding = ObjCProtocol('NSSecureCoding')
 
-        self.assertIsInstance(core_foundation.at(''), NSSecureCoding)
-        self.assertIsInstance(core_foundation.at(''), NSCoding)
+        self.assertIsInstance(at(''), NSSecureCoding)
+        self.assertIsInstance(at(''), NSCoding)
 
         self.assertNotIsInstance(object(), NSSecureCoding)
         self.assertNotIsInstance(NSObject.new(), NSSecureCoding)
@@ -738,7 +738,7 @@ class RubiconTest(unittest.TestCase):
     def test_partial_method_lots_of_args(self):
         pystring = "Uñîçö∂€"
         pybytestring = pystring.encode("utf-8")
-        nsstring = core_foundation.at(pystring)
+        nsstring = at(pystring)
         buf = create_string_buffer(len(pybytestring) + 1)
         usedLength = NSUInteger()
         remaining = NSRange(0, 0)
@@ -977,7 +977,7 @@ class RubiconTest(unittest.TestCase):
     def test_cfstring_to_str(self):
         "CFString/NSString instances can be converted to Python str."
 
-        self.assertEqual(str(core_foundation.at("abcdef")), "abcdef")
+        self.assertEqual(str(at("abcdef")), "abcdef")
 
     def test_objc_const(self):
         "objc_const works."


### PR DESCRIPTION
Implements #74.

This is a rewrite of most of the `core_foundation` module's functions based on Foundation classes, resulting in more readable code with no manual function declarations needed. The only things left in the `core_foundation` module are the basic types/constants/functions used by the ~~`async`~~ `eventloop` module.

The conversion functions have also been restructured a bit. `from_value` and `to_value` have been renamed to `ns_from_py` and `py_from_ns`, because the old names weren't very clear on what direction the conversion went. The `at` function, which previously only produced strings, is now exactly equivalent to `ns_from_py`. This allows things like `at(42)` or `at([1, 2, 3])`, similar to the `@` prefix/operator in Objective-C. The type-specific conversion functions (`to_str`, `to_number`, etc.) have been removed, because `py_from_ns` can be used in place of all of them.

I don't know if the old functions from `core_foundation` are used much externally. I did a quick search through the Toga repo and couldn't find anything except `at` being used. (`at` has only been moved internally, so that shouldn't be an issue.) Are there any other users of Rubicon that I should check for this sort of thing? I know Rubicon isn't officially stable yet, but I still prefer not to break other people's code.

As usual, this PR includes some general cleanup and fixes, so the individual commit diffs may be easier to read than the full diff.