### PR TITLE
Fixes bug on iOS (and other non-macOS) where 'isEqualTo:' is missing for NSObject

### DIFF
--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1117,11 +1117,10 @@ class objc_property(object):
                 if new is not None:
                     new.retain()
             else:
-                if not getattr(_self, '_' + attr).isEqualTo_(new):
-                    getattr(_self, '_' + attr).release()
-                    setattr(_self, '_' + attr, new)
-                    if new is not None:
-                        getattr(_self, '_' + attr).retain()
+                getattr(_self, '_' + attr).autorelease()
+                setattr(_self, '_' + attr, new)
+                if new is not None:
+                    getattr(_self, '_' + attr).retain()
 
         getter_encoding = encoding_from_annotation(getter)
         setter_encoding = encoding_from_annotation(setter)


### PR DESCRIPTION
Fixes issue #98 .

I hope you are ok with it.  It works great in my testing -- but you may be upset that it slightly slightly alters when objects get release and/or semantics.

Another approach would be to check platform -- but on ios simulator platform returns the same thing as on macOS.  

Could also check at startup if NSObject has that selector and set a global flag.. but that would be more invasive.

I went with this approach.  Let me know if it's ok.