### PR TITLE
Properly implement block copy and dispose helpers to allow Python blo…

### DIFF
--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -817,7 +817,11 @@ class ObjCMethod(object):
                     elif isinstance(arg, Block):
                         arg = arg.block
                     else:
-                        arg = Block(arg).block
+                        # This usage below will leverage the ctypes _as_parameter_
+                        # mechanism.
+                        # Note: We need to keep te Block instance around at least until
+                        # the objc method is called else bad things may happen!
+                        arg = Block(arg)
                 elif issubclass(argtype, objc_id):
                     # Convert Python objects to Foundation objects
                     arg = ns_from_py(arg)
@@ -2126,6 +2130,10 @@ class Block:
         )
         self.literal.descriptor = cast(byref(self.descriptor), c_void_p)
         self.block = cast(byref(self.literal), objc_block)
+
+    @property
+    def _as_parameter_(self):
+        return self.block
 
     def wrapper(self, instance, *args):
         return self.func(*args)

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -2128,6 +2128,7 @@ class Block:
 
     def wrapper(self, instance, *args):
         return self.func(*args)
+
     def disposeHelper(self, dst):
         Block._keep_alive_blocks_.pop(self.block.value, None)
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -2065,7 +2065,7 @@ class ObjCBlockInstance(ObjCInstance):
         return self.block(*args)
 
 
-_NSConcreteGlobalBlock = (c_void_p * 32).in_dll(libc, "_NSConcreteGlobalBlock")
+_NSConcreteStackBlock = (c_void_p * 32).in_dll(libc, "_NSConcreteStackBlock")
 
 
 NOTHING = object()
@@ -2107,7 +2107,7 @@ class Block:
         self.cfunc_type = CFUNCTYPE(restype, c_void_p, *signature)
 
         self.literal = BlockLiteral()
-        self.literal.isa = addressof(_NSConcreteGlobalBlock)
+        self.literal.isa = addressof(_NSConcreteStackBlock)
         self.literal.flags = BlockConsts.HAS_STRET | BlockConsts.HAS_SIGNATURE | BlockConsts.HAS_COPY_DISPOSE
         self.literal.reserved = 0
         self.cfunc_wrapper = self.cfunc_type(self.wrapper)

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -2129,10 +2129,7 @@ class Block:
         )
         self.literal.descriptor = cast(byref(self.descriptor), c_void_p)
         self.block = cast(byref(self.literal), objc_block)
-
-    @property
-    def _as_parameter_(self):
-        return self.block
+        self._as_parameter_ = self.block
 
     def wrapper(self, instance, *args):
         return self.func(*args)

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -814,13 +814,15 @@ class ObjCMethod(object):
                     if arg is None:
                         # allow for 'nil' block args, which some objc methods accept
                         arg = ns_from_py(arg)
-                    elif isinstance(arg, Block):
-                        arg = arg.block
-                    else:
-                        # This usage below will leverage the ctypes _as_parameter_
-                        # mechanism.  Note: We need to keep the temp. Block instance 
+                    elif callable(arg) and \
+                         not isinstance(arg, Block): # <-- guard against someone someday making Block callable
+                        # Note: We need to keep the temp. Block instance
                         # around at least until the objc method is called.
+                        # _as_parameter_ is used in the actual ctypes marshalling below.
                         arg = Block(arg)
+                    # ^ For blocks at this point either arg is a Block instance
+                    # (making use of _as_parameter_), is None, or if it isn't either of
+                    # those two, an ArgumentError will be raised below.
                 elif issubclass(argtype, objc_id):
                     # Convert Python objects to Foundation objects
                     arg = ns_from_py(arg)

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -814,8 +814,8 @@ class ObjCMethod(object):
                     if arg is None:
                         # allow for 'nil' block args, which some objc methods accept
                         arg = ns_from_py(arg)
-                    elif callable(arg) and \
-                         not isinstance(arg, Block): # <-- guard against someone someday making Block callable
+                    elif (callable(arg) and
+                          not isinstance(arg, Block)):  # <-- guard against someone someday making Block callable
                         # Note: We need to keep the temp. Block instance
                         # around at least until the objc method is called.
                         # _as_parameter_ is used in the actual ctypes marshalling below.
@@ -1962,9 +1962,11 @@ def objc_const(dll, name):
 
     return ObjCInstance(objc_id.in_dll(dll, name))
 
-_cfunc_type_block_invoke  = CFUNCTYPE(c_void_p, c_void_p)
+
+_cfunc_type_block_invoke = CFUNCTYPE(c_void_p, c_void_p)
 _cfunc_type_block_dispose = CFUNCTYPE(c_void_p, c_void_p)
-_cfunc_type_block_copy    = CFUNCTYPE(c_void_p, c_void_p, c_void_p)
+_cfunc_type_block_copy = CFUNCTYPE(c_void_p, c_void_p, c_void_p)
+
 
 class ObjCBlockStruct(Structure):
     _fields_ = [
@@ -1991,7 +1993,7 @@ class BlockLiteral(Structure):
         ('isa', c_void_p),
         ('flags', c_int),
         ('reserved', c_int),
-        ('invoke', c_void_p), # NB: this must be c_void_p due to variadic nature
+        ('invoke', c_void_p),  # NB: this must be c_void_p due to variadic nature
         ('descriptor', c_void_p)
     ]
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -2125,6 +2125,9 @@ class Block:
         # to objc methods via ctypes
         self._as_parameter_ = self.block
 
+    def __call__(self, *args):
+        return self.func(*args)
+
     def wrapper(self, instance, *args):
         return self.func(*args)
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -810,7 +810,20 @@ class ObjCMethod(object):
                     # Convert Python enum objects to their values
                     arg = arg.value
 
-                if issubclass(argtype, objc_id):
+                if issubclass(argtype, objc_block):
+                    if arg is None:
+                        # allow for 'nil' block args, which some objc methods accept
+                        arg = ns_from_py(arg)
+                    elif callable(arg) and \
+                         not isinstance(arg, Block): # <-- guard against someone someday making Block callable
+                        # Note: We need to keep the temp. Block instance
+                        # around at least until the objc method is called.
+                        # _as_parameter_ is used in the actual ctypes marshalling below.
+                        arg = Block(arg)
+                    # ^ For blocks at this point either arg is a Block instance
+                    # (making use of _as_parameter_), is None, or if it isn't either of
+                    # those two, an ArgumentError will be raised below.
+                elif issubclass(argtype, objc_id):
                     # Convert Python objects to Foundation objects
                     arg = ns_from_py(arg)
                 elif isinstance(arg, collections.abc.Iterable) and issubclass(argtype, (Structure, Array)):
@@ -1755,7 +1768,6 @@ def ns_from_py(pyobj):
     * ``dict``: Converted to ``NSDictionary``, with all keys and values converted recursively
     * ``list``: Converted to ``NSArray``, with all elements converted recursively
     * ``bool``, ``int``, ``float``: Converted to ``NSNumber``
-    *  ``typing.Callable``: functions/closures are converted to our ``Block`` facade (suitable to be passed to objc)
 
     Other types cause a ``TypeError``.
     """
@@ -1765,7 +1777,7 @@ def ns_from_py(pyobj):
 
     # Many Objective-C method calls here use the convert_result=False kwarg to disable automatic conversion of
     # return values, because otherwise most of the Objective-C objects would be converted back to Python objects.
-    if pyobj is None or isinstance(pyobj, ObjCInstance) or isinstance(pyobj, Block):
+    if pyobj is None or isinstance(pyobj, ObjCInstance):
         return pyobj
     elif isinstance(pyobj, str):
         return ObjCInstance(NSString.stringWithUTF8String_(pyobj.encode('utf-8'), convert_result=False))
@@ -1789,8 +1801,6 @@ def ns_from_py(pyobj):
         return ObjCInstance(NSNumber.numberWithLong_(pyobj, convert_result=False))
     elif isinstance(pyobj, float):
         return ObjCInstance(NSNumber.numberWithDouble_(pyobj, convert_result=False))
-    elif callable(pyobj):
-        return Block(pyobj)
     else:
         raise TypeError(
             "Don't know how to convert a {cls.__module__}.{cls.__qualname__} to a Foundation object"
@@ -2121,8 +2131,6 @@ class Block:
         )
         self.literal.descriptor = cast(byref(self.descriptor), c_void_p)
         self.block = cast(byref(self.literal), objc_block)
-        # below is needed so that Block is a first class object that can be marshalled
-        # to objc methods via ctypes
         self._as_parameter_ = self.block
 
     def wrapper(self, instance, *args):

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -818,9 +818,8 @@ class ObjCMethod(object):
                         arg = arg.block
                     else:
                         # This usage below will leverage the ctypes _as_parameter_
-                        # mechanism.
-                        # Note: We need to keep te Block instance around at least until
-                        # the objc method is called else bad things may happen!
+                        # mechanism.  Note: We need to keep the temp. Block instance 
+                        # around at least until the objc method is called.
                         arg = Block(arg)
                 elif issubclass(argtype, objc_id):
                     # Convert Python objects to Foundation objects

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -2125,9 +2125,6 @@ class Block:
         # to objc methods via ctypes
         self._as_parameter_ = self.block
 
-    def __call__(self, *args):
-        return self.func(*args)
-
     def wrapper(self, instance, *args):
         return self.func(*args)
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1986,7 +1986,7 @@ class BlockLiteral(Structure):
         ('isa', c_void_p),
         ('flags', c_int),
         ('reserved', c_int),
-        ('invoke', c_void_p), # NB: this must be c_void_p due to polymorphic nature
+        ('invoke', c_void_p), # NB: this must be c_void_p due to variadic nature
         ('descriptor', c_void_p)
     ]
 


### PR DESCRIPTION
…ck objects to have the same semantics as objc.

This means you can do Block(somePyFun) and it will stay around if obj-c side retained it (as in an asynch callback).

Previously this lead to a crash.

Also added a fixup so you can pass 'None' to methods expecting a block parameter -- as this is supported by many of the Foundation/iOS/etc APIs.

The only thing I am unsure of with this PR is whether on the copy, we need to explicitly copy back in the descriptor, etc structs.  I am fuzzy on C/Python ctypes,etc semantics so it's not that easy for me to do it, and it didn't seem necessary, so I left it out.

Any comments or suggestions are appreciated.
