### PR TITLE
Install and test with multiple Python versions on Travis using pyenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   # The different Travis environments have different pyenv versions, and not all have the Python versions we need,
   # so we upgrade pyenv to get a consistent setup in all environments.
   - brew update
-  - brew upgrade pyenv
+  - brew outdated pyenv || brew upgrade pyenv
   # pyenv's shims directory is not in the PATH by default.
   - export PATH="$(pyenv root)/shims:${PATH}"
   # These are the Python versions that we want to test on.

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,28 @@ branches:
 os: osx
 matrix:
   include:
+    # Note: The ordering of the environments is optimized so that the complete matrix runs as quickly as possible,
+    # while also providing the first results as early as possible.
+    # At the moment, build times for each environment are roughly as follows:
+    # xcode6.4: 13 minutes
+    # xcode7.3: 5 minutes
+    # xcode8.3: 3 minutes
+    # xcode9.2: 2 minutes
+    # This data is based on the following build, which should be similar to most builds on the repo:
+    # https://travis-ci.org/pybee/rubicon-objc/builds/348992202
+    # Currently, Travis allows a maximum of two concurrent Mac builds per owner:
+    # https://blog.travis-ci.com/2017-09-22-macos-update
+    # With the following order, xcode6.4 will take up the first slot, and at the same time the three other
+    # environments use the second slot in sequence. xcode9.2 will finish first and provide some early results - most
+    # test failures happen in all environments and will be quickly reported this way. 
+
     # OSX 10.10 Yosemite
     - osx_image: xcode6.4
+    # macOS 10.12 Sierra
+    - osx_image: xcode9.2
+    - osx_image: xcode8.3
     # OSX 10.11 El Capitan
     - osx_image: xcode7.3
-    # macOS 10.12 Sierra
-    - osx_image: xcode8.3
-    - osx_image: xcode9.2
 language: generic
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,29 @@ matrix:
     - osx_image: xcode8.3
     - osx_image: xcode9.2
 language: generic
+cache:
+  directories:
+    ~/.pyenv
+env:
+  global:
+    - PY34="3.4.8"
+    - PY35="3.5.5"
+    - PY36="3.6.4"
 install:
+  # The different Travis environments have different pyenv versions, and not all have the Python versions we need,
+  # so we upgrade pyenv to get a consistent setup in all environments.
   - brew update
-  - brew install python3
-  - python3 -m pip install tox
+  - brew upgrade pyenv
+  # pyenv's shims directory is not in the PATH by default.
+  - export PATH="$(pyenv root)/shims:${PATH}"
+  # These are the Python versions that we want to test on.
+  - pyenv install --skip-existing ${PY34}
+  - pyenv install --skip-existing ${PY35}
+  - pyenv install --skip-existing ${PY36}
+  - pyenv global ${PY36} ${PY35} ${PY34} system
+  # tox is not installed by default in some older Travis environments.
+  - python3.6 -m pip install tox
   - make -f Makefile
 script:
   - export DYLD_LIBRARY_PATH=`pwd`/tests/objc
-  - python3 setup.py test
-  - python3 -m tox -e flake8
+  - python3.6 -m tox -e "py{34,35,36}-default"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,4 @@ install:
   - make -f Makefile
 script:
   - export DYLD_LIBRARY_PATH=`pwd`/tests/objc
-  - python3.6 -m tox -e "py{34,35,36}-default"
+  - python3.6 -m tox -e "py{34,35,36}-default,flake8"


### PR DESCRIPTION
This changes the Travis config to use `pyenv` instead of `brew` to install Python.

The original motivation for this change was that our Travis builds are currently broken. `brew install python3` is failing, because the Travis environment has Python 2 installed by default, and for some reason Homebrew is refusing to install Python 3 because of that. (I think it's because Homebrew's handling of Python 2/3 has changed - `python3` is now an alias for `python`, which refers to Python 3, and if you want Python 2 you need to explicitly use `python@2`. However the Travis environment has Python 2.7 installed as `python` rather than `python@2`, which is why it causes a conflict when we try to install Python 3.)

However Travis also comes with `pyenv` preinstalled, which provides much more control about what Python versions are installed than Homebrew does. And since, unlike Homebrew, it allows installing multiple Python versions at once, I decided to try installing all Python versions that we have `tox` configurations for. This should allow us to run `tox` on Travis.

~~This PR is still WIP while I figure out how `pyenv` works (haven't used it before) - please don't merge yet!~~