### PR TITLE
Proposed fix to send_super 

### DIFF
--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -15,7 +15,7 @@ from .runtime import (  # noqa: F401
     IMP, SEL, Block, Class, Ivar, Method, NSArray, NSDictionary, NSMutableArray, NSMutableDictionary, NSObject,
     NSObjectProtocol, ObjCBlock, ObjCClass, ObjCInstance, ObjCMetaClass, ObjCProtocol, at, ns_from_py,
     objc_classmethod, objc_const, objc_id, objc_ivar, objc_method, objc_property, objc_property_t, objc_rawmethod,
-    py_from_ns, send_message, send_super, get_class,
+    py_from_ns, send_message, send_super,
 )
 from .types import (  # noqa: F401
     CFIndex, CFRange, CGFloat, CGGlyph, CGPoint, CGPointMake, CGRect,

--- a/rubicon/objc/__init__.py
+++ b/rubicon/objc/__init__.py
@@ -15,7 +15,7 @@ from .runtime import (  # noqa: F401
     IMP, SEL, Block, Class, Ivar, Method, NSArray, NSDictionary, NSMutableArray, NSMutableDictionary, NSObject,
     NSObjectProtocol, ObjCBlock, ObjCClass, ObjCInstance, ObjCMetaClass, ObjCProtocol, at, ns_from_py,
     objc_classmethod, objc_const, objc_id, objc_ivar, objc_method, objc_property, objc_property_t, objc_rawmethod,
-    py_from_ns, send_message, send_super,
+    py_from_ns, send_message, send_super, get_class,
 )
 from .types import (  # noqa: F401
     CFIndex, CFRange, CGFloat, CGGlyph, CGPoint, CGPointMake, CGRect,

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -688,7 +688,7 @@ def send_super(receiver, selName, *args, **kwargs):
         if isinstance(superclass, Class):
             pass  # ok, accept Class instances, I guess
         elif not isinstance(superclass, str):  # expecting a string here.. complain
-            raise TypeError("Invalid type for 'superclass' kwarg, expected type str, got: %"
+            raise TypeError("Invalid type for 'superclass' kwarg, expected type str, got: %s"
                             % (str(type(superclass))))
         else:
             classname = superclass

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -682,14 +682,12 @@ def send_super(cls, receiver, selName, *args, **kwargs):
 
     cls may also be a naked Class pointer.
     """
-    if isinstance(cls, Class) or type(cls) is ObjCClass:
-        pass
-    else:
+    if not isinstance(cls, (ObjCClass, Class)):
         # Kindly remind the caller that the API has changed
         raise TypeError("Missing/Invalid cls argument: '{tp.__module__}.{tp.__qualname__}' -- "
                         .format(tp=type(cls))
                         + "send_super now requires its first argument be an"
-                        + " ObjClass or an objc raw Class pointer."
+                        + " ObjCClass or an objc raw Class pointer."
                         + " To fix this error, use Python's __class__ keyword as the first argument to"
                         + " send_super.")
 

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -681,7 +681,10 @@ def send_super(receiver, selName, *args, **kwargs):
     else:
         raise TypeError("Invalid type for receiver: {tp.__module__}.{tp.__qualname__}".format(tp=type(receiver)))
 
-    superclass = get_superclass_of_object(receiver)
+    superclass = kwargs.get('superclass', None)
+    if superclass is not None and not isinstance(superclass, Class):
+        raise TypeError("Invalid type for 'superclass' kwarg, expected type 'Class', got: %" % (str(type(superclass))))
+    superclass = get_superclass_of_object(receiver) if superclass is None else superclass
     super_struct = objc_super(receiver, superclass)
     selector = SEL(selName)
     restype = kwargs.get('restype', c_void_p)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -999,13 +999,13 @@ class RubiconTest(unittest.TestCase):
             @objc_method
             def computeSize_(self, input: NSSize) -> NSSize:
                 results['size'] = True
-                sup = send_super(self, 'computeSize:', input, restype=NSSize, argtypes=[NSSize])
+                sup = send_super(__class__, self, 'computeSize:', input, restype=NSSize, argtypes=[NSSize])
                 return NSSize(input.width + self.value, sup.height)
 
             @objc_method
             def computeRect_(self, input: NSRect) -> NSRect:
                 results['rect'] = True
-                sup = send_super(self, 'computeRect:', input, restype=NSRect, argtypes=[NSRect])
+                sup = send_super(__class__, self, 'computeRect:', input, restype=NSRect, argtypes=[NSRect])
                 return NSMakeRect(
                     input.origin.y + self.value, sup.origin.x,
                     input.size.height + self.value, sup.size.width


### PR DESCRIPTION
Related: Issue #107 

I'm not sure if my approach is the most elegant.. but at least it has the same semantics as what obj-c does for you at compile-time.

The idea is the caller tells send_super where to start looking, which 100% emulates what the compiler does in obj-c for you.  

If they omit the keyword, they get the (possibly incorrect) automatic behavior we had before.

Not sure how elegant this is though.  Maybe we can do better.  But this is better than nothing IMHO.

Let me know what you think!

Tested on the following code and it works like a charm:

Code:

```
class MyA(NSObject):
    
    aProp = objc_property()
    
    @objc_method
    def init(self) -> ObjCInstance:
        #self = ObjCInstance(send_super(self, 'init', superclass='NSObject'))
        self = ObjCInstance(send_super(__class__, self, 'init'))
        print ("MyA init")
        self.aProp = "MyA Property"
        return self
    
    @objc_method
    def dealloc(self) -> None:
        print ("MyA dealloc")
        self.aProp = None
        #send_super(self, 'dealloc', superclass='NSObject')     
        send_super(__class__, self, 'dealloc')     

class MyB(MyA):
    
    bProp = objc_property()
    
    @objc_method
    def init(self) -> ObjCInstance:
        #self = ObjCInstance(send_super(self, 'init', superclass='MyA'))
        self = ObjCInstance(send_super(__class__, self, 'init'))
        print ("MyB init")
        self.aProp = "MyB Property, overwritten"
        self.bProp = "MyB's own property"
        return self
    
    @objc_method
    def dealloc(self) -> None:
        print ("MyB dealloc")
        self.bProp = None
        #send_super(self, 'dealloc', superclass='MyA')
        send_super(__class__, self, 'dealloc')

# ... then, somewhere in a function or whatever ... 

    a=MyB.new().autorelease()
    print("MyB propA=%s propB=%s"%(str(a.aProp),str(a.bProp)))



```
Output:

```
MyA init
MyB init
MyB propA=MyB Property, overwritten propB=MyB's own property
MyB dealloc
MyA dealloc

```

__EDIT__: Updated this comment to reflect changed API as discussed below (so that someone googling has good usage to look at in front of their eyes rather than non-existant usage).
