### PR TITLE
Fix DeprecationWarning when using __class__ in an Objective-C subclass 

### DIFF
--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1431,6 +1431,7 @@ class ObjCClass(ObjCInstance, type):
         protocols_ptr = libobjc.class_copyProtocolList(self, byref(out_count))
         return tuple(ObjCProtocol(protocols_ptr[i]) for i in range(out_count.value))
 
+    @classmethod
     def _new_from_name(cls, name):
         name = ensure_bytes(name)
         ptr = get_class(name)
@@ -1439,6 +1440,7 @@ class ObjCClass(ObjCInstance, type):
 
         return ptr, name
 
+    @classmethod
     def _new_from_ptr(cls, ptr):
         ptr = cast(ptr, Class)
         if ptr.value is None:
@@ -1449,6 +1451,7 @@ class ObjCClass(ObjCInstance, type):
 
         return ptr, name
 
+    @classmethod
     def _new_from_class_statement(cls, name, bases, attrs, *, protocols):
         name = ensure_bytes(name)
 
@@ -1525,13 +1528,13 @@ class ObjCClass(ObjCInstance, type):
             attrs = {}
 
             if isinstance(name_or_ptr, (bytes, str)):
-                ptr, name = cls._new_from_name(cls, name_or_ptr)
+                ptr, name = cls._new_from_name(name_or_ptr)
             else:
-                ptr, name = cls._new_from_ptr(cls, name_or_ptr)
+                ptr, name = cls._new_from_ptr(name_or_ptr)
                 if not issubclass(cls, ObjCMetaClass) and libobjc.class_isMetaClass(ptr):
                     return ObjCMetaClass(ptr)
         else:
-            ptr, name, attrs = cls._new_from_class_statement(cls, name_or_ptr, bases, attrs, protocols=protocols)
+            ptr, name, attrs = cls._new_from_class_statement(name_or_ptr, bases, attrs, protocols=protocols)
 
         objc_class_name = name.decode('utf-8')
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,5 +25,10 @@ setenv =
 
 [testenv:flake8]
 basepython = python3.6
-deps = flake8
+# FIXME Remove the pyflakes git dependency once a new version of pyflakes (> 1.6.0) is released.
+# Currently we need to use the development version of pyflakes in order to use __class__, because pyflakes <= 1.6.0
+# doesn't understand __class__. This has been fixed in the development version, but not in any release yet.
+deps =
+    flake8
+    git+https://github.com/PyCQA/pyflakes.git
 commands = flake8 {posargs}


### PR DESCRIPTION
On Python 3.6 and later, when a class definition uses the special `__class__` variable, the metaclass receives a `__classcell__` entry in the class namespace. The metaclass must retain this entry in the namespace passed to `type.__new__`. ([Relevant Python docs](https://docs.python.org/3/reference/datamodel.html#creating-the-class-object).)

When creating an Objective-C subclass in Python, `ObjCClass` discards the entire namespace (because everything was translated to Objective-C methods, properties, etc.), which means that `__classcell__` is removed from the namespace and not passed on automatically. This PR adds a special case for `__classcell__` to keep it around.

This is relevant to #108.