### PR TITLE
Add ObjCStrInstance and disable automatic NSString-to-str conversion (fixes #101)

### DIFF
--- a/docs/background/releases.rst
+++ b/docs/background/releases.rst
@@ -4,6 +4,11 @@ Release History
 (next version)
 --------------
 
+* Added Pythonic operators and methods on ``NSString`` objects, similar to those for ``NSArray`` and ``NSDictionary``.
+  * Only a small subset of the standard ``str`` methods is supported at the moment. Additional ``str`` methods may be implemented in the future, but some methods (like ``format``) will never be supported, as they cannot be implemented efficiently based on ``NSString``.
+* Removed automatic conversion of ``NSString`` objects to ``str`` when returned from Objective-C methods. This feature made it difficult to call Objective-C methods on ``NSString`` objects, because there was no easy way to prevent the automatic conversion.
+  * In most cases, this change will not affect existing code, because ``NSString`` objects now support operations similar to ``str``.
+  * If an actual ``str`` object is required, the ``NSString`` object can be wrapped in a ``str`` call to convert it.
 * Fixed various bugs in the collection ``ObjCInstance`` subclasses:
   * Fixed getting/setting/deleting items or slices with indices lower than ``-len(obj)``. Previously this crashed Python, now an ``IndexError`` is raised.
   * Fixed slices with step size 0. Previously they were ignored and 1 was incorrectly used as the step size, now an ``IndexError`` is raised.

--- a/docs/how-to/type-mapping.rst
+++ b/docs/how-to/type-mapping.rst
@@ -93,23 +93,3 @@ When you need to pass an Objective C structure to an Objective C method,
 you can pass a tuple instead. For example, if you pass (10.0, 5.1) where a
 `NSSize` is expected, it will be converted automatically in the appropriate
 width, height for the structure.
-
-Prevent type conversion
------------------------
-
-For some use cases you may not actually want to do an automatic type conversion.
-For example if you need to make use of an actual `NSString` object in a Python
-program, you need the ability to prevent automatic conversion in to `str`.
-
-To prevent type conversion, pass `convert_result=False` as a parameter. An
-example of this in action would be to create a text string in Python:
-
-.. code-block:: python
-
-    text_string = ObjCInstance(
-        ObjCInstance(NSString.alloc(convert_result=False)).initWithString_(text, convert_result=False)
-    )
-
-As you can see in the example above, the initialization of the `NSString` has to
-be unwrapped twice. This use case will be supported better in the future with
-the creation of an `ObjCStringInstance` like there is for dictionaries.

--- a/docs/how-to/type-mapping.rst
+++ b/docs/how-to/type-mapping.rst
@@ -53,6 +53,33 @@ Python type name can be used as the annotation type. You can also use any of
 the `ctypes` primitive types. Rubicon also provides type definitions for common
 Objective-C typedefs, like `NSInteger`, `CGFloat`, and so on.
 
+Strings
+-------
+
+If a method calls for an `NSString` argument, you can provide a Python `str`
+for that argument. Rubicon will construct an `NSString` instance from the data
+in the `str` provided, and pass that value for the argument.
+
+If a method returns an `NSString`, the return value will be a wrapped
+`ObjCStrInstance` type. This type implements a `str`-like interface, wrapped
+around the underlying `NSString` data. This means you can treat the return
+value as if it were a string - slicing it, concatenating it with other strings,
+comparing it, and so on.
+
+Note that `ObjCStrInstance` objects behave slightly differently than Python
+`str` objects in some cases. For technical reasons, `ObjCStrInstance` objects
+are not hashable, which means they cannot be used as `dict` keys (but they
+*can* be used as `NSDictionary` keys). `ObjCStrInstance` also handles Unicode
+code points above U+FFFF differently than Python `str`, because the underlying
+`NSString` is based on UTF-16.
+
+At the moment `ObjCStrInstance` does not yet support many methods that are
+available on `str`. More methods will be implemented in the future, such as
+`replace` and `split`. However some methods will likely never be available on
+`ObjCStrInstance` as they would be too complex to reimplement, such as `format`
+and `encode`. If you need to use a method that `ObjCStrInstance` doesn't
+support, you can use `str(nsstring)` to convert it to `str`.
+
 Lists
 -----
 

--- a/rubicon/objc/collections.py
+++ b/rubicon/objc/collections.py
@@ -2,8 +2,8 @@ import operator
 
 from .types import NSUInteger, NSNotFound, NSRange, unichar
 from .runtime import (
-    NSArray, NSDictionary, NSMutableArray, NSMutableDictionary, NSString, ObjCInstance, for_objcclass, ns_from_py, objc_id,
-    py_from_ns, send_message,
+    NSArray, NSDictionary, NSMutableArray, NSMutableDictionary, NSString, ObjCInstance, for_objcclass, ns_from_py,
+    objc_id, py_from_ns, send_message,
 )
 
 

--- a/rubicon/objc/collections.py
+++ b/rubicon/objc/collections.py
@@ -1,7 +1,7 @@
 from .types import NSUInteger, NSNotFound, NSRange, unichar
 from .runtime import (
     NSArray, NSDictionary, NSMutableArray, NSMutableDictionary, NSString, ObjCInstance, for_objcclass, ns_from_py, objc_id,
-    send_message
+    py_from_ns, send_message,
 )
 
 
@@ -213,7 +213,7 @@ class ObjCDictInstance(ObjCInstance):
         return self.objectForKey_(item) is not None
 
     def __eq__(self, other):
-        return dict(self) == other
+        return py_from_ns(self) == other
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/rubicon/objc/collections.py
+++ b/rubicon/objc/collections.py
@@ -1,4 +1,4 @@
-from .types import NSUInteger, NSNotFound, NSRange
+from .types import NSUInteger, NSNotFound, NSRange, unichar
 from .runtime import (
     NSArray, NSDictionary, NSMutableArray, NSMutableDictionary, NSString, ObjCInstance, for_objcclass, ns_from_py, objc_id,
     send_message
@@ -46,7 +46,11 @@ class ObjCStrInstance(ObjCInstance):
             if step == 1:
                 return self.substringWithRange(NSRange(start, stop-start))
             else:
-                raise NotImplementedError('{cls.__name__} slicing with step != 1'.format(cls=type(self)))
+                rng = range(start, stop, step)
+                chars = (unichar * len(rng))()
+                for chars_i, self_i in enumerate(rng):
+                    chars[chars_i] = ord(self[self_i])
+                return NSString.stringWithCharacters(chars, length=len(chars))
         else:
             if key < 0:
                 index = len(self) + key

--- a/rubicon/objc/collections.py
+++ b/rubicon/objc/collections.py
@@ -37,7 +37,7 @@ class ObjCStrInstance(ObjCInstance):
     # isinstance(NSString.string(), NSMutableString) is true.
 
     def __len__(self):
-        return self.count
+        return self.length
 
     def __getitem__(self, key):
         if isinstance(key, slice):

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1319,13 +1319,10 @@ class ObjCInstance(object):
         return self
 
     def __str__(self):
-        if isinstance(self, NSString):
-            return self.UTF8String.decode('utf-8')
-        else:
-            desc = self.description
-            if desc is None:
-                raise ValueError('{self.name}.description returned nil'.format(self=self))
-            return desc
+        desc = self.description
+        if desc is None:
+            raise ValueError('{self.name}.description returned nil'.format(self=self))
+        return str(desc)
 
     def __repr__(self):
         return "<%s.%s %#x: %s at %#x: %s>" % (

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1732,9 +1732,11 @@ def py_from_ns(nsobj, *, _auto=False):
                 .format(objc_type)
             )
     elif _auto:
-        # _auto is a private kwarg that is only passed when py_from_ns is called to perform an implicit conversion
-        # of a method return value or argument into Python. In this case we only want to perform a few simple
-        # conversions (boxed numbers to their Python equivalents).
+        # If py_from_ns is called implicitly to convert an Objective-C method's return value, only the conversions
+        # before this branch are performed. If py_from_ns is called explicitly by hand, the additional conversions
+        # below this branch are performed as well.
+        # _auto is a private kwarg that is only passed when py_from_ns is called implicitly. In that case, we return
+        # early and don't attempt any other conversions.
         return nsobj
     elif nsobj.isKindOfClass(NSString):
         return str(nsobj)

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1713,7 +1713,7 @@ def py_from_ns(nsobj, *, _auto=False):
         return nsobj
 
     if nsobj.isKindOfClass(NSDecimalNumber):
-        return decimal.Decimal(nsobj.descriptionWithLocale(None))
+        return decimal.Decimal(str(nsobj.descriptionWithLocale(None)))
     elif nsobj.isKindOfClass(NSNumber):
         # Choose the property to access based on the type encoding. The actual conversion is done by ctypes.
         # Signed and unsigned integers are in separate cases to prevent overflow with unsigned long longs.

--- a/rubicon/objc/runtime.py
+++ b/rubicon/objc/runtime.py
@@ -1715,9 +1715,7 @@ def py_from_ns(nsobj, *, _auto=False):
     if not isinstance(nsobj, ObjCInstance):
         return nsobj
 
-    if nsobj.isKindOfClass(NSString):
-        return str(nsobj)
-    elif nsobj.isKindOfClass(NSDecimalNumber):
+    if nsobj.isKindOfClass(NSDecimalNumber):
         return decimal.Decimal(nsobj.descriptionWithLocale(None))
     elif nsobj.isKindOfClass(NSNumber):
         # Choose the property to access based on the type encoding. The actual conversion is done by ctypes.
@@ -1739,8 +1737,10 @@ def py_from_ns(nsobj, *, _auto=False):
     elif _auto:
         # _auto is a private kwarg that is only passed when py_from_ns is called to perform an implicit conversion
         # of a method return value or argument into Python. In this case we only want to perform a few simple
-        # conversions (strings and numbers).
+        # conversions (boxed numbers to their Python equivalents).
         return nsobj
+    elif nsobj.isKindOfClass(NSString):
+        return str(nsobj)
     elif nsobj.isKindOfClass(NSData):
         # Despite the name, string_at converts the data at the address to a bytes object, not str.
         return string_at(send_message(nsobj, 'bytes', restype=POINTER(c_uint8), argtypes=[]), nsobj.length)

--- a/tests/test_NSDictionary.py
+++ b/tests/test_NSDictionary.py
@@ -51,10 +51,10 @@ class NSDictionaryMixinTest(unittest.TestCase):
     def test_iter(self):
         d = self.make_dictionary(self.py_dict)
 
-        keys = set(self.py_dict)
+        keys = {str(k) for k in self.py_dict}
         for k in d:
-            self.assertTrue(k in keys)
-            keys.remove(k)
+            self.assertTrue(str(k) in keys)
+            keys.remove(str(k))
 
         self.assertTrue(len(keys) == 0)
 
@@ -104,17 +104,20 @@ class NSDictionaryMixinTest(unittest.TestCase):
 
     def test_keys(self):
         a = self.make_dictionary(self.py_dict)
-        for k1, k2 in zip(sorted(a.keys()), sorted(self.py_dict.keys())):
+        for k1, k2 in zip(sorted(a.keys(), key=str), sorted(self.py_dict.keys())):
             self.assertEqual(k1, k2)
 
     def test_values(self):
         a = self.make_dictionary(self.py_dict)
-        for v1, v2 in zip(sorted(a.values()), sorted(self.py_dict.values())):
+        for v1, v2 in zip(sorted(a.values(), key=str), sorted(self.py_dict.values())):
             self.assertEqual(v1, v2)
 
     def test_items(self):
         d = self.make_dictionary(self.py_dict)
-        for i1, i2 in zip(sorted(d.items()), sorted(self.py_dict.items())):
+        for i1, i2 in zip(
+            sorted(d.items(), key=lambda item: (str(item[0]), str(item[1]))),
+            sorted(self.py_dict.items()),
+        ):
             self.assertEqual(i1[0], i2[0])
             self.assertEqual(i1[1], i2[1])
 
@@ -206,12 +209,12 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
     def test_popitem(self):
         d = self.make_dictionary(self.py_dict)
 
-        keys = set(self.py_dict)
+        keys = {str(k) for k in self.py_dict}
 
         while len(d) > 0:
             key, value = d.popitem()
-            self.assertTrue(key in keys)
-            self.assertEqual(value, self.py_dict[key])
+            self.assertTrue(str(key) in keys)
+            self.assertEqual(value, self.py_dict[str(key)])
             self.assertTrue(key not in d)
 
         with self.assertRaises(KeyError):

--- a/tests/test_NSDictionary.py
+++ b/tests/test_NSDictionary.py
@@ -51,7 +51,7 @@ class NSDictionaryMixinTest(unittest.TestCase):
     def test_iter(self):
         d = self.make_dictionary(self.py_dict)
 
-        keys = {str(k) for k in self.py_dict}
+        keys = set(self.py_dict)
         for k in d:
             self.assertTrue(str(k) in keys)
             keys.remove(str(k))
@@ -206,7 +206,7 @@ class NSMutableDictionaryMixinTest(NSDictionaryMixinTest):
     def test_popitem(self):
         d = self.make_dictionary(self.py_dict)
 
-        keys = {str(k) for k in self.py_dict}
+        keys = set(self.py_dict)
 
         while len(d) > 0:
             key, value = d.popitem()

--- a/tests/test_NSDictionary.py
+++ b/tests/test_NSDictionary.py
@@ -104,20 +104,17 @@ class NSDictionaryMixinTest(unittest.TestCase):
 
     def test_keys(self):
         a = self.make_dictionary(self.py_dict)
-        for k1, k2 in zip(sorted(a.keys(), key=str), sorted(self.py_dict.keys())):
+        for k1, k2 in zip(sorted(a.keys()), sorted(self.py_dict.keys())):
             self.assertEqual(k1, k2)
 
     def test_values(self):
         a = self.make_dictionary(self.py_dict)
-        for v1, v2 in zip(sorted(a.values(), key=str), sorted(self.py_dict.values())):
+        for v1, v2 in zip(sorted(a.values()), sorted(self.py_dict.values())):
             self.assertEqual(v1, v2)
 
     def test_items(self):
         d = self.make_dictionary(self.py_dict)
-        for i1, i2 in zip(
-            sorted(d.items(), key=lambda item: (str(item[0]), str(item[1]))),
-            sorted(self.py_dict.items()),
-        ):
+        for i1, i2 in zip(sorted(d.items()), sorted(self.py_dict.items())):
             self.assertEqual(i1[0], i2[0])
             self.assertEqual(i1[1], i2[1])
 

--- a/tests/test_NSDictionary.py
+++ b/tests/test_NSDictionary.py
@@ -53,7 +53,6 @@ class NSDictionaryMixinTest(unittest.TestCase):
 
         keys = set(self.py_dict)
         for k in d:
-            self.assertTrue(str(k) in keys)
             keys.remove(str(k))
 
         self.assertTrue(len(keys) == 0)

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -22,6 +22,9 @@ faulthandler.enable()
 
 class NSStringTests(unittest.TestCase):
     TEST_STRINGS = ('', 'abcdef', 'Uñîçö∂€')
+    HAYSTACK = 'abcdabcdabcdef'
+    NEEDLES = ['', 'a', 'bcd', 'def', HAYSTACK, 'nope', 'dcb']
+    RANGES = [(None, None), (None, 6), (6, None), (4, 10)]
 
     def test_str_nsstring_conversion(self):
         """Python str and NSString can be converted to each other manually."""
@@ -57,6 +60,19 @@ class NSStringTests(unittest.TestCase):
         self.assertNotEqual(ns_first, py_second)
         self.assertEqual(py_second, ns_second)
         self.assertEqual(ns_second, py_second)
+
+    def test_nsstring_in(self):
+        """The in operator works on NSString."""
+
+        py_haystack = type(self).HAYSTACK
+        ns_haystack = ns_from_py(py_haystack)
+        for py_needle in type(self).NEEDLES:
+            with self.subTest(py_needle=py_needle):
+                ns_needle = ns_from_py(py_needle)
+                if py_needle in py_haystack:
+                    self.assertIn(ns_needle, ns_haystack)
+                else:
+                    self.assertNotIn(ns_needle, ns_haystack)
 
     def test_nsstring_len(self):
         """len() works on NSString."""
@@ -95,3 +111,47 @@ class NSStringTests(unittest.TestCase):
                 nsstr = ns_from_py(pystr)
                 for nschar, pychar in zip(nsstr, pystr):
                     self.assertEqual(nschar, pychar)
+
+    def test_nsstring_find_rfind(self):
+        """The find and rfind methods work on NSString."""
+
+        py_haystack = type(self).HAYSTACK
+        ns_haystack = ns_from_py(py_haystack)
+        for py_needle in type(self).NEEDLES:
+            for start, end in type(self).RANGES:
+                with self.subTest(py_needle=py_needle, start=start, end=end):
+                    ns_needle = ns_from_py(py_needle)
+                    self.assertEqual(
+                        ns_haystack.find(ns_needle, start, end),
+                        py_haystack.find(py_needle, start, end),
+                    )
+                    self.assertEqual(
+                        ns_haystack.rfind(ns_needle, start, end),
+                        py_haystack.rfind(py_needle, start, end),
+                    )
+
+    def test_nsstring_index_rindex(self):
+        """The index and rindex methods work on NSString."""
+
+        py_haystack = type(self).HAYSTACK
+        ns_haystack = ns_from_py(py_haystack)
+        for py_needle in type(self).NEEDLES:
+            for start, end in type(self).RANGES:
+                with self.subTest(py_needle=py_needle, start=start, end=end):
+                    ns_needle = ns_from_py(py_needle)
+    
+                    try:
+                        index = py_haystack.index(py_needle, start, end)
+                    except ValueError:
+                        with self.assertRaises(ValueError):
+                            ns_haystack.index(ns_needle, start, end)
+                    else:
+                        self.assertEqual(ns_haystack.index(ns_needle, start, end), index)
+    
+                    try:
+                        rindex = py_haystack.rindex(py_needle, start, end)
+                    except ValueError:
+                        with self.assertRaises(ValueError):
+                            ns_haystack.rindex(ns_needle, start, end)
+                    else:
+                        self.assertEqual(ns_haystack.rindex(ns_needle, start, end), rindex)

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -86,3 +86,12 @@ class NSStringTests(unittest.TestCase):
                     self.assertEqual(nsstr[:3:step], pystr[:3:step])
                     self.assertEqual(nsstr[2::step], pystr[2::step])
                     self.assertEqual(nsstr[1:4:step], pystr[1:4:step])
+
+    def test_nsstring_iter(self):
+        """A NSString can be iterated over."""
+
+        for pystr in type(self).TEST_STRINGS:
+            with self.subTest(pystr=pystr):
+                nsstr = ns_from_py(pystr)
+                for nschar, pychar in zip(nsstr, pystr):
+                    self.assertEqual(nschar, pychar)

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -155,3 +155,29 @@ class NSStringTests(unittest.TestCase):
                             ns_haystack.rindex(ns_needle, start, end)
                     else:
                         self.assertEqual(ns_haystack.rindex(ns_needle, start, end), rindex)
+
+    def test_nsstring_add_radd(self):
+        """The + operator works on NSString."""
+
+        for py_left in type(self).TEST_STRINGS:
+            for py_right in type(self).TEST_STRINGS:
+                with self.subTest(py_left=py_left, py_right=py_right):
+                    ns_left = ns_from_py(py_left)
+                    ns_right = ns_from_py(py_right)
+                    py_concat = py_left + py_right
+                    ns_concat = ns_from_py(py_concat)
+                    self.assertEqual(ns_left + ns_right, ns_concat)
+                    self.assertEqual(py_left + ns_right, ns_concat)
+                    self.assertEqual(ns_left + py_right, ns_concat)
+
+    def test_nsstring_mul_rmul(self):
+        """The * operator works on NSString."""
+
+        for py_str in type(self).TEST_STRINGS:
+            for n in (-5, 0, 1, 2, 5):
+                with self.subTest(py_str=py_str, n=n):
+                    ns_str = ns_from_py(py_str)
+                    py_repeated = py_str * n
+                    ns_repeated = ns_from_py(py_repeated)
+                    self.assertEqual(ns_str * n, ns_repeated)
+                    self.assertEqual(n * ns_str, ns_repeated)

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -62,6 +62,20 @@ class NSStringTests(unittest.TestCase):
         self.assertEqual(py_second, ns_second)
         self.assertEqual(ns_second, py_second)
 
+    def test_nsstring_compare(self):
+        """A NSString can be compared to other strings."""
+
+        for py_left in type(self).TEST_STRINGS:
+            for py_right in type(self).TEST_STRINGS:
+                with self.subTest(py_left=py_left, py_right=py_right):
+                    ns_left = ns_from_py(py_left)
+                    ns_right = ns_from_py(py_right)
+
+                    self.assertEqual(ns_left < ns_right, py_left < py_right)
+                    self.assertEqual(ns_left <= ns_right, py_left <= py_right)
+                    self.assertEqual(ns_left >= ns_right, py_left >= py_right)
+                    self.assertEqual(ns_left > ns_right, py_left > py_right)
+
     def test_nsstring_in(self):
         """The in operator works on NSString."""
 

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -20,6 +20,7 @@ rubiconharness = CDLL(rubiconharness_name)
 
 faulthandler.enable()
 
+
 class NSStringTests(unittest.TestCase):
     TEST_STRINGS = ('', 'abcdef', 'Uñîçö∂€')
     HAYSTACK = 'abcdabcdabcdef'
@@ -139,7 +140,7 @@ class NSStringTests(unittest.TestCase):
             for start, end in type(self).RANGES:
                 with self.subTest(py_needle=py_needle, start=start, end=end):
                     ns_needle = ns_from_py(py_needle)
-    
+
                     try:
                         index = py_haystack.index(py_needle, start, end)
                     except ValueError:
@@ -147,7 +148,7 @@ class NSStringTests(unittest.TestCase):
                             ns_haystack.index(ns_needle, start, end)
                     else:
                         self.assertEqual(ns_haystack.index(ns_needle, start, end), index)
-    
+
                     try:
                         rindex = py_haystack.rindex(py_needle, start, end)
                     except ValueError:

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -1,0 +1,88 @@
+import faulthandler
+import unittest
+from ctypes import CDLL, util
+
+from rubicon.objc import ns_from_py, py_from_ns
+from rubicon.objc.runtime import NSString
+
+try:
+    import platform
+    OSX_VERSION = tuple(int(v) for v in platform.mac_ver()[0].split('.')[:2])
+except Exception:
+    OSX_VERSION = None
+
+
+# Load the test harness library
+rubiconharness_name = util.find_library('rubiconharness')
+if rubiconharness_name is None:
+    raise RuntimeError("Couldn't load Rubicon test harness library. Have you set DYLD_LIBRARY_PATH?")
+rubiconharness = CDLL(rubiconharness_name)
+
+faulthandler.enable()
+
+class NSStringTests(unittest.TestCase):
+    TEST_STRINGS = ('', 'abcdef', 'Uñîçö∂€')
+
+    def test_str_nsstring_conversion(self):
+        """Python str and NSString can be converted to each other manually."""
+
+        for pystr in type(self).TEST_STRINGS:
+            with self.subTest(pystr=pystr):
+                nsstr = ns_from_py(pystr)
+                self.assertIsInstance(nsstr, NSString)
+                self.assertEqual(str(nsstr), pystr)
+                self.assertEqual(py_from_ns(nsstr), pystr)
+
+    def test_nsstring_eq_nsstring(self):
+        """Two NSStrings can be checked for equality."""
+
+        first = ns_from_py('first')
+        second = ns_from_py('second')
+
+        self.assertEqual(first, first)
+        self.assertNotEqual(first, second)
+        self.assertEqual(second, second)
+
+    def test_str_eq_nsstring(self):
+        """A Python str and a NSString can be checked for equality."""
+
+        py_first = 'first'
+        py_second = 'second'
+        ns_first = ns_from_py(py_first)
+        ns_second = ns_from_py(py_second)
+
+        self.assertEqual(py_first, ns_first)
+        self.assertEqual(ns_first, py_first)
+        self.assertNotEqual(py_first, ns_second)
+        self.assertNotEqual(ns_first, py_second)
+        self.assertEqual(py_second, ns_second)
+        self.assertEqual(ns_second, py_second)
+
+    def test_nsstring_len(self):
+        """len() works on NSString."""
+
+        for pystr in type(self).TEST_STRINGS:
+            with self.subTest(pystr=pystr):
+                nsstr = ns_from_py(pystr)
+                self.assertEqual(len(nsstr), len(pystr))
+
+    def test_nsstring_getitem_index(self):
+        """The individual elements of a NSString can be accessed."""
+
+        for pystr in type(self).TEST_STRINGS:
+            with self.subTest(pystr=pystr):
+                nsstr = ns_from_py(pystr)
+                for i, pychar in enumerate(pystr):
+                    self.assertEqual(nsstr[i], pychar)
+
+    def test_nsstring_getitem_slice(self):
+        """A NSString can be sliced."""
+
+        for pystr in type(self).TEST_STRINGS:
+            for step in (None, 1, 2, -1, -2):
+                with self.subTest(pystr=pystr, step=step):
+                    nsstr = ns_from_py(pystr)
+                    self.assertEqual(nsstr[::step], pystr[::step])
+                    self.assertEqual(nsstr[:3:step], pystr[:3:step])
+                    self.assertEqual(nsstr[2::step], pystr[2::step])
+                    self.assertEqual(nsstr[1:4:step], pystr[1:4:step])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -973,11 +973,6 @@ class RubiconTest(unittest.TestCase):
         self.assertEqual(insets.bottom, other_insets.bottom)
         self.assertEqual(insets.right, other_insets.right)
 
-    def test_cfstring_to_str(self):
-        "CFString/NSString instances can be converted to Python str."
-
-        self.assertEqual(str(at("abcdef")), "abcdef")
-
     def test_objc_const(self):
         "objc_const works."
 


### PR DESCRIPTION
This disables the automatic conversion of `NSString` objects to `str` when returned from Objective-C methods, as discussed in #101. As a replacement, it adds an internal `ObjCStrInstance` class, which provides Pythonic operators and methods on `NSString` objects. (This is similar to what `ObjCListInstance` does for `NSArray` objects.)

There are a few small differences between "real" `str`s and `ObjCStrInstance` objects:

* `str`s consist of Unicode code points, whereas `NSString`s consist of UTF-16 code units. (See the `ObjCStrInstance` docstring for a longer explanation.) I've chosen to use the `NSString` behavior for `ObjCStrInstance`, because attempting to emulate the Python `str` behavior would be very complicated and error-prone. In practice the difference rarely matters, and when it does, the `NSString` can be converted to a `str`.
* `ObjCStrInstance` does not implement all the operations that `str` supports, only the most common ones (indexing, slicing, `+`, `*`, `in`, `find`, `index`). It might be useful to implement some additional methods in the future, such as `replace`, `partition`, `split`, and `join`. Others aren't worth reimplementing, either because they are too complex (`format`, `encode`) or too rarely used (`center`, `expandtabs`). If one of the missing methods is needed, the `NSString` can be converted to a `str`.