### PR TITLE
Fixes #115 - Add more methods on the ObjCString interface.

### DIFF
--- a/docs/how-to/type-mapping.rst
+++ b/docs/how-to/type-mapping.rst
@@ -29,94 +29,99 @@ Primitives
 If a Python value needs to be passed in as a primitive, Rubicon will wrap the
 primitive:
 
-===== =============================================================
-Value C primitive
-===== ============================================================
-bool  8 bit integer (although it can only hold 2 values - 0 and 1)
-int   32 bit integer
-float double precision floating point
-===== ============================================================
+============== ============================================================
+Value          C primitive
+============== ============================================================
+:class:`bool`  8 bit integer (although it can only hold 2 values - 0 and 1)
+:class:`int`   32 bit integer
+:class:`float` double precision floating point
+============== ============================================================
 
 If a Python value needs to be passed in as an object, Rubicon will wrap the
 primitive in an object:
 
-===== =================
-Value Objective C type
-===== =================
-bool  NSNumber (bool)
-int   NSNumber (long)
-float NSNumber (double)
-===== =================
+============== ==========================
+Value          Objective C type
+============== ==========================
+:class:`bool`  :class:`NSNumber` (bool)
+:class:`int`   :class:`NSNumber` (long)
+:class:`float` :class:`NSNumber` (double)
+============== ==========================
 
 If you're declaring a method and need to annotate the type of an argument, the
 Python type name can be used as the annotation type. You can also use any of
-the `ctypes` primitive types. Rubicon also provides type definitions for common
-Objective-C typedefs, like `NSInteger`, `CGFloat`, and so on.
+the ``ctypes`` primitive types. Rubicon also provides type definitions for common
+Objective-C typedefs, like :class:`NSInteger`, :class:`CGFloat`, and so on.
 
 Strings
 -------
 
-If a method calls for an `NSString` argument, you can provide a Python `str`
-for that argument. Rubicon will construct an `NSString` instance from the data
-in the `str` provided, and pass that value for the argument.
+If a method calls for an :class:`NSString` argument, you can provide a Python
+:class:`str` for that argument. Rubicon will construct an :class:`NSString`
+instance from the data in the :class:`str` provided, and pass that value for
+the argument.
 
-If a method returns an `NSString`, the return value will be a wrapped
-`ObjCStrInstance` type. This type implements a `str`-like interface, wrapped
-around the underlying `NSString` data. This means you can treat the return
-value as if it were a string - slicing it, concatenating it with other strings,
-comparing it, and so on.
+If a method returns an :class:`NSString`, the return value will be a wrapped
+:class:`ObjCStrInstance` type. This type implements a :class:`str`-like
+interface, wrapped around the underlying :class:`NSString` data. This means
+you can treat the return value as if it were a string - slicing it,
+concatenating it with other strings, comparing it, and so on.
 
-Note that `ObjCStrInstance` objects behave slightly differently than Python
-`str` objects in some cases. For technical reasons, `ObjCStrInstance` objects
-are not hashable, which means they cannot be used as `dict` keys (but they
-*can* be used as `NSDictionary` keys). `ObjCStrInstance` also handles Unicode
-code points above U+FFFF differently than Python `str`, because the underlying
-`NSString` is based on UTF-16.
+Note that :class:`ObjCStrInstance` objects behave slightly differently than
+Python :class:`str` objects in some cases. For technical reasons,
+:class:`ObjCStrInstance` objects are not hashable, which means they cannot be
+used as :class:`dict` keys (but they *can* be used as :class:`NSDictionary`
+keys). :class:`ObjCStrInstance` also handles Unicode code points above
+``U+FFFF`` differently than Python :class:`str`, because the underlying
+:class:`NSString` is based on UTF-16.
 
-At the moment `ObjCStrInstance` does not yet support many methods that are
-available on `str`. More methods will be implemented in the future, such as
-`replace` and `split`. However some methods will likely never be available on
-`ObjCStrInstance` as they would be too complex to reimplement, such as `format`
-and `encode`. If you need to use a method that `ObjCStrInstance` doesn't
-support, you can use `str(nsstring)` to convert it to `str`.
+If you have an :class:`ObjCStrInstance` instance, and you need to pass that
+instance to a method that does a specific typecheck for `str`, you can use
+:class:`str(nsstring)` to convert the :class:`ObjCStrInstance` instance to
+:class:`str`.
+
+:class:`ObjCStrInstance` implements all the utility methods that are available
+on :class:`str`, such as ``replace`` and ``split``. These utility methods all
+return *Python* strings.
 
 Lists
 -----
 
-If a method calls for an `NSArray` or `NSMutableArray` argument, you can
-provide a Python `list` for that argument. Rubicon will construct an
-`NSMutableArray` instance from the data in the `list` provided, and pass that
-value for the argument.
+If a method calls for an :class:`NSArray` or :class:`NSMutableArray` argument,
+you can provide a Python :class:`list` for that argument. Rubicon will
+construct an :class:`NSMutableArray` instance from the data in the
+:class:`list` provided, and pass that value for the argument.
 
-If a method returns an `NSArray` or `NSMutableArray`, the return value will be
-a wrapped `ObjCListInstance` type. This type implements a `list`-like
-interface, wrapped around the underlying `NSArray` data. This means you can
-treat the return value as if it were a list - iterating over values, retrieving
-objects by index, and so on.
+If a method returns an :class:`NSArray` or :class:`NSMutableArray`, the return
+value will be a wrapped :class:`ObjCListInstance` type. This type implements a
+:class:`list`-like interface, wrapped around the underlying :class:`NSArray`
+data. This means you can treat the return value as if it were a list -
+iterating over values, retrieving objects by index, and so on.
 
 Dictionaries
 ------------
 
-If a method calls for an `NSDictionary` or `NSMutableDictionary` argument, you
-can provide a Python `dict`. Rubicon will construct an `NSMutableDictionary`
-instance from the data in the `dict` provided, and pass that value for the
-argument.
+If a method calls for an :class:`NSDictionary` or :class:`NSMutableDictionary`
+argument, you can provide a Python :class:`dict`. Rubicon will construct an
+:class:`NSMutableDictionary` instance from the data in the :class:`dict`
+provided, and pass that value for the argument.
 
-If a method returns an `NSDictionary` or `NSMutableDictionary`, the return
-value will be a wrapped `ObjCDictInstance` type. This type implements a
-`dict`-like interface, wrapped around the underlying `NSDictionary` data. This
-means you can treat the return value as if it were a dict - iterating over
-keys, values or items, retrieving objects by key, and so on.
+If a method returns an :class:`NSDictionary` or :class:`NSMutableDictionary`,
+the return value will be a wrapped :class:`ObjCDictInstance` type. This type
+implements a :class:`dict`-like interface, wrapped around the underlying
+:class:`NSDictionary` data. This means you can treat the return value as if it
+were a dict - iterating over keys, values or items, retrieving objects by key,
+and so on.
 
 
-`NSPoint`, `NSSize`, and `NSRect`
----------------------------------
+:class:`NSPoint`, :class:`NSSize`, and :class:`NSRect`
+------------------------------------------------------
 
 On instances of an Objective C structure, each field is exposed as a Python
-attribute. For example, if you create an instance of an `NSSize` object you can
-access its width and height by calling `NSSize.width`.
+attribute. For example, if you create an instance of an :class:`NSSize` object
+you can access its width and height by calling :meth:`NSSize.width`.
 
 When you need to pass an Objective C structure to an Objective C method,
 you can pass a tuple instead. For example, if you pass (10.0, 5.1) where a
-`NSSize` is expected, it will be converted automatically in the appropriate
+:class:`NSSize` is expected, it will be converted automatically in the appropriate
 width, height for the structure.

--- a/docs/how-to/type-mapping.rst
+++ b/docs/how-to/type-mapping.rst
@@ -65,7 +65,16 @@ If a method returns an :class:`NSString`, the return value will be a wrapped
 :class:`ObjCStrInstance` type. This type implements a :class:`str`-like
 interface, wrapped around the underlying :class:`NSString` data. This means
 you can treat the return value as if it were a string - slicing it,
-concatenating it with other strings, comparing it, and so on.
+concatenating it with other strings, comparing it, and so on::
+
+    # Call an Objective C method that returns a string.
+    # We're using NSBundle to give us a string version of a path
+    >>> NSBundle.mainBundle.bundlePath
+    <rubicon.objc.collections.ObjCStrInstance 0x114a94d68: __NSCFString at 0x7fec8ba7fbd0: /Users/brutus/path/to/somewhere>
+
+    # Slice the Objective C string
+    >>> NSBundle.mainBundle.bundlePath[:14]
+    <rubicon.objc.collections.ObjCStrInstance 0x114aa80f0: __NSCFString at 0x7fec8ba7fbd0: /Users/brutus/>
 
 Note that :class:`ObjCStrInstance` objects behave slightly differently than
 Python :class:`str` objects in some cases. For technical reasons,
@@ -78,14 +87,39 @@ keys). :class:`ObjCStrInstance` also handles Unicode code points above
 If you have an :class:`ObjCStrInstance` instance, and you need to pass that
 instance to a method that does a specific typecheck for :class:`str`, you can
 use ``str(nsstring)`` to convert the :class:`ObjCStrInstance` instance to
-:class:`str`.
+:class:`str`::
+
+    # Convert the Objective C string to a Python string.
+    >>> str(NSBundle.mainBundle.bundlePath)
+    '/Users/rkm/projects/beeware/venv3.6/bin'
+
+Conversely, if you have a :class:`str`, and you specifically require a
+:class:`ObjCStrInstance` instance, you can use the :meth:`at()` method to
+convert the Python instance to an :class:`ObjCStrInstance`.
+
+    >>> from rubicon.objc import at
+    # Create a Python string
+    >>> py_str = 'hello world'
+
+    # Convert to an Objective C string
+    >>> at(py_str)
+    <rubicon.objc.collections.ObjCStrInstance 0x114a94e48: __NSCFString at 0x7fec8ba7fc10: hello world>
 
 :class:`ObjCStrInstance` implements all the utility methods that are available
 on :class:`str`, such as ``replace`` and ``split``. When these methods return
 a string, the implementation may return Python :class:`str` or
 :class:`ObjCStrInstance` instances. If you need to use the return value from
 these methods, you should always use ``str()`` to ensure you have a Python
-string.
+string::
+
+    # Is the path comprised of all lowercase letters? (Hint: it isn't)
+    >>> NSBundle.mainBundle.bundlePath.islower()
+    False
+
+    # Convert string to lower case; use str() to ensure we get a Python string.
+    >>> str(NSBundle.mainBundle.bundlePath.lower())
+    '/users/rkm/projects/beeware/venv3.6/bin'
+
 
 Lists
 -----

--- a/docs/how-to/type-mapping.rst
+++ b/docs/how-to/type-mapping.rst
@@ -76,13 +76,16 @@ keys). :class:`ObjCStrInstance` also handles Unicode code points above
 :class:`NSString` is based on UTF-16.
 
 If you have an :class:`ObjCStrInstance` instance, and you need to pass that
-instance to a method that does a specific typecheck for `str`, you can use
-:class:`str(nsstring)` to convert the :class:`ObjCStrInstance` instance to
+instance to a method that does a specific typecheck for :class:`str`, you can
+use ``str(nsstring)`` to convert the :class:`ObjCStrInstance` instance to
 :class:`str`.
 
 :class:`ObjCStrInstance` implements all the utility methods that are available
-on :class:`str`, such as ``replace`` and ``split``. These utility methods all
-return *Python* strings.
+on :class:`str`, such as ``replace`` and ``split``. When these methods return
+a string, the implementation may return Python :class:`str` or
+:class:`ObjCStrInstance` instances. If you need to use the return value from
+these methods, you should always use ``str()`` to ensure you have a Python
+string.
 
 Lists
 -----

--- a/rubicon/objc/collections.py
+++ b/rubicon/objc/collections.py
@@ -32,6 +32,9 @@ class ObjCStrInstance(ObjCInstance):
     def __str__(self):
         return self.UTF8String.decode('utf-8')
 
+    def __fspath__(self):
+        return self.__str__()
+
     def __eq__(self, other):
         if isinstance(other, str):
             return self.isEqualToString(ns_from_py(other))

--- a/rubicon/objc/collections.py
+++ b/rubicon/objc/collections.py
@@ -178,92 +178,11 @@ class ObjCStrInstance(ObjCInstance):
         else:
             return found
 
-    def capitalize(self):
-        return str(self).capitalize()
-
-    def casefold(self):
-        return str(self).casefold()
-
-    def center(self, width, fillchar=' '):
-        return str(self).center(width, fillchar)
-
-    def count(self, sub, start=None, end=None):
-        return str(self).count(sub, start, end)
-
-    def encode(self, encoding='utf-8', errors='strict'):
-        return str(self).encode(encoding, errors=errors)
-
-    def endswith(self, sub, start=None, end=None):
-        return str(self).endswith(sub, start, end)
-
-    def expandtabs(self, tabsize=8):
-        return str(self).expandtabs(tabsize)
-
     def find(self, sub, start=None, end=None):
         return self._find(sub, start=start, end=end, reverse=False)
 
-    def format(self, *args, **kwargs):
-        return str(self).format(*args, **kwargs)
-
-    def format_map(self, mapping):
-        return str(self).format_map(mapping)
-
     def index(self, sub, start=None, end=None):
         return self._index(sub, start=start, end=end, reverse=False)
-
-    def isalnum(self):
-        return str(self).isalnum()
-
-    def isalpha(self):
-        return str(self).isalpha()
-
-    def isdecimal(self):
-        return str(self).isdecimal()
-
-    def isdigit(self):
-        return str(self).isdigit()
-
-    def isidentifier(self):
-        return str(self).isidentifier()
-
-    def islower(self):
-        return str(self).islower()
-
-    def isnumeric(self):
-        return str(self).isnumeric()
-
-    def isprintable(self):
-        return str(self).isprintable()
-
-    def isspace(self):
-        return str(self).isspace()
-
-    def istitle(self):
-        return str(self).istitle()
-
-    def isupper(self):
-        return str(self).isupper()
-
-    def join(self, iterable):
-        return str(self).join(iterable)
-
-    def ljust(self, width, fillchar=' '):
-        return str(self).ljust(width, fillchar)
-
-    def lower(self):
-        return str(self).lower()
-
-    def lstrip(self, chars=None):
-        return str(self).lstrip(chars)
-
-    def maketrans(self, x, *args, **kwargs):
-        return str(self).maketrans(x, *args, **kwargs)
-
-    def partition(self, sep):
-        return str(self).partition(sep)
-
-    def replace(self, old, new, count=-1):
-        return str(self).replace(old, new, count)
 
     def rfind(self, sub, start=None, end=None):
         return self._find(sub, start=start, end=end, reverse=True)
@@ -271,41 +190,14 @@ class ObjCStrInstance(ObjCInstance):
     def rindex(self, sub, start=None, end=None):
         return self._index(sub, start=start, end=end, reverse=True)
 
-    def rjust(self, width, fillchar=' '):
-        return str(self).rjust(width, fillchar)
-
-    def rpartition(self, sep):
-        return str(self).rpartition(sep)
-
-    def rsplit(self, sep=None, maxsplit=-1):
-        return str(self).rsplit(sep=sep, maxsplit=maxsplit)
-
-    def rstrip(self, chars=None):
-        return str(self).rstrip(chars)
-
-    def split(self, sep=None, maxsplit=-1):
-        return str(self).split(sep=sep, maxsplit=maxsplit)
-
-    def splitlines(self, keepends=False):
-        return str(self).splitlines()
-
-    def strip(self, chars=None):
-        return str(self).strip(chars)
-
-    def swapcase(self):
-        return str(self).swapcase()
-
-    def title(self):
-        return str(self).title()
-
-    def translate(self, table):
-        return str(self).translate(table)
-
-    def upper(self):
-        return str(self).upper()
-
-    def zfill(self, width):
-        return str(self).zfill(width)
+    # A fallback method; get the locally defined attribute if it exists;
+    # otherwise, get the attribute from the Python-converted version
+    # of the string
+    def __getattr__(self, attr):
+        try:
+            return super().__getattr__(attr)
+        except AttributeError:
+            return getattr(self.__str__(), attr)
 
 
 @for_objcclass(NSArray)

--- a/rubicon/objc/collections.py
+++ b/rubicon/objc/collections.py
@@ -168,12 +168,6 @@ class ObjCStrInstance(ObjCInstance):
         else:
             return found_range.location
 
-    def find(self, sub, start=None, end=None):
-        return self._find(sub, start=start, end=end, reverse=False)
-
-    def rfind(self, sub, start=None, end=None):
-        return self._find(sub, start=start, end=end, reverse=True)
-
     def _index(self, sub, start=None, end=None, *, reverse):
         found = self._find(sub, start, end, reverse=reverse)
         if found == -1:
@@ -181,11 +175,134 @@ class ObjCStrInstance(ObjCInstance):
         else:
             return found
 
+    def capitalize(self):
+        return str(self).capitalize()
+
+    def casefold(self):
+        return str(self).casefold()
+
+    def center(self, width, fillchar=' '):
+        return str(self).center(width, fillchar)
+
+    def count(self, sub, start=None, end=None):
+        return str(self).count(sub, start, end)
+
+    def encode(self, encoding='utf-8', errors='strict'):
+        return str(self).encode(encoding, errors=errors)
+
+    def endswith(self, sub, start=None, end=None):
+        return str(self).endswith(sub, start, end)
+
+    def expandtabs(self, tabsize=8):
+        return str(self).expandtabs(tabsize)
+
+    def find(self, sub, start=None, end=None):
+        return self._find(sub, start=start, end=end, reverse=False)
+
+    def format(self, *args, **kwargs):
+        return str(self).format(*args, **kwargs)
+
+    def format_map(self, mapping):
+        return str(self).format_map(mapping)
+
     def index(self, sub, start=None, end=None):
         return self._index(sub, start=start, end=end, reverse=False)
 
+    def isalnum(self):
+        return str(self).isalnum()
+
+    def isalpha(self):
+        return str(self).isalpha()
+
+    def isdecimal(self):
+        return str(self).isdecimal()
+
+    def isdigit(self):
+        return str(self).isdigit()
+
+    def isidentifier(self):
+        return str(self).isidentifier()
+
+    def islower(self):
+        return str(self).islower()
+
+    def isnumeric(self):
+        return str(self).isnumeric()
+
+    def isprintable(self):
+        return str(self).isprintable()
+
+    def isspace(self):
+        return str(self).isspace()
+
+    def istitle(self):
+        return str(self).istitle()
+
+    def isupper(self):
+        return str(self).isupper()
+
+    def join(self, iterable):
+        return str(self).join(iterable)
+
+    def ljust(self, width, fillchar=' '):
+        return str(self).ljust(width, fillchar)
+
+    def lower(self):
+        return str(self).lower()
+
+    def lstrip(self, chars=None):
+        return str(self).lstrip(chars)
+
+    def maketrans(self, x, *args, **kwargs):
+        return str(self).maketrans(x, *args, **kwargs)
+
+    def partition(self, sep):
+        return str(self).partition(sep)
+
+    def replace(self, old, new, count=-1):
+        return str(self).replace(old, new, count)
+
+    def rfind(self, sub, start=None, end=None):
+        return self._find(sub, start=start, end=end, reverse=True)
+
     def rindex(self, sub, start=None, end=None):
         return self._index(sub, start=start, end=end, reverse=True)
+
+    def rjust(self, width, fillchar=' '):
+        return str(self).rjust(width, fillchar)
+
+    def rpartition(self, sep):
+        return str(self).rpartition(sep)
+
+    def rsplit(self, sep=None, maxsplit=-1):
+        return str(self).rsplit(sep=sep, maxsplit=maxsplit)
+
+    def rstrip(self, chars=None):
+        return str(self).rstrip(chars)
+
+    def split(self, sep=None, maxsplit=-1):
+        return str(self).split(sep=sep, maxsplit=maxsplit)
+
+    def splitlines(self, keepends=False):
+        return str(self).splitlines()
+
+    def strip(self, chars=None):
+        return str(self).strip(chars)
+
+    def swapcase(self):
+        return str(self).swapcase()
+
+    def title(self):
+        return str(self).title()
+
+    def translate(self, table):
+        return str(self).translate(table)
+
+    def upper(self):
+        return str(self).upper()
+
+    def zfill(self, width):
+        return str(self).zfill(width)
 
 
 @for_objcclass(NSArray)

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -1,4 +1,5 @@
 import faulthandler
+import os
 import unittest
 from ctypes import CDLL, util
 
@@ -61,6 +62,15 @@ class NSStringTests(unittest.TestCase):
         self.assertNotEqual(ns_first, py_second)
         self.assertEqual(py_second, ns_second)
         self.assertEqual(ns_second, py_second)
+
+    def test_nsstring_as_fspath(self):
+        """An NSString can be interpreted as a 'path-like' object"""
+
+        # os.path.dirname requires a 'path-like' object.
+        self.assertEqual(
+            os.path.dirname(ns_from_py('/path/base/leaf')),
+            '/path/base'
+        )
 
     def test_nsstring_compare(self):
         """A NSString can be compared to other strings."""

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -196,3 +196,212 @@ class NSStringTests(unittest.TestCase):
                     ns_repeated = ns_from_py(py_repeated)
                     self.assertEqual(ns_str * n, ns_repeated)
                     self.assertEqual(n * ns_str, ns_repeated)
+
+    def test_nsstring_capitalize(self):
+        ns_str = ns_from_py('lower, UPPER & Mixed!')
+        self.assertEqual(ns_str.capitalize(), 'Lower, upper & mixed!')
+
+    def test_nsstring_casefold(self):
+        ns_str = ns_from_py('lower, UPPER & Mixed!')
+        self.assertEqual(ns_str.casefold(), 'lower, upper & mixed!')
+
+    def test_nsstring_center(self):
+        ns_str = ns_from_py('hello')
+        self.assertEqual(ns_str.center(20), '       hello        ')
+        self.assertEqual(ns_str.center(20, '*'), '*******hello********')
+
+    def test_nsstring_count(self):
+        ns_str = ns_from_py('hello world')
+        self.assertEqual(ns_str.count('x'), 0)
+        self.assertEqual(ns_str.count('l'), 3)
+        self.assertEqual(ns_str.count('l', start=5), 1)
+        self.assertEqual(ns_str.count('l', end=8), 2)
+        self.assertEqual(ns_str.count('l', start=4, end=8), 0)
+
+    def test_nsstring_encode(self):
+        ns_str = ns_from_py('Uñîçö∂€ string')
+        self.assertEqual(ns_str.encode('utf-8'), b'U\xc3\xb1\xc3\xae\xc3\xa7\xc3\xb6\xe2\x88\x82\xe2\x82\xac string')
+        self.assertEqual(ns_str.encode('utf-16'), b'\xff\xfeU\x00\xf1\x00\xee\x00\xe7\x00\xf6\x00\x02"\xac  \x00s\x00t\x00r\x00i\x00n\x00g\x00')
+
+        with self.assertRaises(UnicodeEncodeError):
+            ns_str.encode('ascii')
+        self.assertEqual(ns_str.encode('ascii', 'ignore'), b'U string')
+
+    def test_nsstring_endswith(self):
+        ns_str = ns_from_py('Hello world')
+        self.assertTrue(ns_str.endswith('world'))
+        self.assertFalse(ns_str.endswith('cake'))
+
+    def test_nsstring_expandtabs(self):
+        ns_str = ns_from_py('hello\tworld')
+        self.assertEqual(ns_str.expandtabs(), 'hello   world')
+        self.assertEqual(ns_str.expandtabs(4), 'hello   world')
+        self.assertEqual(ns_str.expandtabs(10), 'hello     world')
+
+    def test_nsstring_format(self):
+        ns_str = ns_from_py('hello {}')
+        self.assertEqual(ns_str.format('world'), 'hello world')
+
+    def test_nsstring_format_map(self):
+        ns_str = ns_from_py('hello {name}')
+        self.assertEqual(ns_str.format_map({'name': 'world'}), 'hello world')
+
+    def test_nsstring_isalnum(self):
+        self.assertTrue(ns_from_py('abcd').isalnum())
+        self.assertTrue(ns_from_py('1234').isalnum())
+        self.assertTrue(ns_from_py('abcd1234').isalnum())
+
+    def test_nsstring_isalpha(self):
+        self.assertTrue(ns_from_py('abcd').isalpha())
+        self.assertFalse(ns_from_py('1234').isalpha())
+        self.assertFalse(ns_from_py('abcd1234').isalpha())
+
+    def test_nsstring_isdecimal(self):
+        self.assertFalse(ns_from_py('abcd').isdecimal())
+        self.assertTrue(ns_from_py('1234').isdecimal())
+        self.assertFalse(ns_from_py('abcd1234').isdecimal())
+
+    def test_nsstring_isdigit(self):
+        self.assertFalse(ns_from_py('abcd').isdigit())
+        self.assertTrue(ns_from_py('1234').isdigit())
+        self.assertFalse(ns_from_py('abcd1234').isdigit())
+
+    def test_nsstring_isidentifier(self):
+        ns_str = ns_from_py('')
+        self.assertTrue(ns_from_py('def').isidentifier())
+        self.assertTrue(ns_from_py('class').isidentifier())
+        self.assertTrue(ns_from_py('hello').isidentifier())
+        self.assertFalse(ns_from_py('boo!').isidentifier())
+
+    def test_nsstring_islower(self):
+        self.assertTrue(ns_from_py('abcd').islower())
+        self.assertFalse(ns_from_py('ABCD').islower())
+        self.assertFalse(ns_from_py('1234').islower())
+        self.assertTrue(ns_from_py('abcd1234').islower())
+        self.assertFalse(ns_from_py('ABCD1234').islower())
+
+    def test_nsstring_isnumeric(self):
+        self.assertFalse(ns_from_py('abcd').isdigit())
+        self.assertTrue(ns_from_py('1234').isdigit())
+        self.assertFalse(ns_from_py('abcd1234').isdigit())
+
+    def test_nsstring_isprintable(self):
+        self.assertFalse(ns_from_py('\x09').isprintable())
+        self.assertTrue(ns_from_py('Hello').isprintable())
+
+    def test_nsstring_isspace(self):
+        self.assertTrue(ns_from_py(' ').isspace())
+        self.assertTrue(ns_from_py('   ').isspace())
+        self.assertFalse(ns_from_py('Hello world').isspace())
+        self.assertFalse(ns_from_py('Hello').isspace())
+
+    def test_nsstring_istitle(self):
+        self.assertTrue(ns_from_py('Hello World').istitle())
+        self.assertFalse(ns_from_py('hello world').istitle())
+        self.assertFalse(ns_from_py('Hello world').istitle())
+        self.assertFalse(ns_from_py('Hello WORLD').istitle())
+        self.assertFalse(ns_from_py('HELLO WORLD').istitle())
+
+    def test_nsstring_isupper(self):
+        self.assertFalse(ns_from_py('abcd').isupper())
+        self.assertTrue(ns_from_py('ABCD').isupper())
+        self.assertFalse(ns_from_py('1234').isupper())
+        self.assertFalse(ns_from_py('abcd1234').isupper())
+        self.assertTrue(ns_from_py('ABCD1234').isupper())
+
+    def test_nsstring_join(self):
+        ns_str = ns_from_py(':')
+        self.assertEqual(ns_str.join(['aa', 'bb', 'cc']), 'aa:bb:cc')
+
+    def test_nsstring_ljust(self):
+        ns_str = ns_from_py('123')
+        self.assertEqual(ns_str.ljust(5), '123  ')
+        self.assertEqual(ns_str.ljust(5, '*'), '123**')
+
+    def test_nsstring_lower(self):
+        ns_str = ns_from_py('lower, UPPER & Mixed!')
+        self.assertEqual(ns_str.lower(), 'lower, upper & mixed!')
+
+    def test_nsstring_lstrip(self):
+        ns_str = ns_from_py('   hello   ')
+        self.assertEqual(ns_str.lstrip(), 'hello   ')
+
+        ns_str = ns_from_py('...hello...')
+        self.assertEqual(ns_str.lstrip('.'), 'hello...')
+
+    def test_nsstring_maketrans(self):
+        ns_str = ns_from_py('hello')
+        self.assertEqual(ns_str.maketrans('lo', 'g!'), {108: 103, 111: 33})
+
+    def test_nsstring_partition(self):
+        ns_str = ns_from_py('hello new world')
+        self.assertEqual(ns_str.partition(' '), ('hello', ' ', 'new world'))
+        self.assertEqual(ns_str.partition('l'), ('he', 'l', 'lo new world'))
+
+    def test_nsstring_replace(self):
+        ns_str = ns_from_py('hello new world')
+        self.assertEqual(ns_str.replace('new', 'old'), 'hello old world')
+        self.assertEqual(ns_str.replace('l', '!'), 'he!!o new wor!d')
+        self.assertEqual(ns_str.replace('l', '!', 2), 'he!!o new world')
+
+    def test_nsstring_rjust(self):
+        ns_str = ns_from_py('123')
+        self.assertEqual(ns_str.rjust(5), '  123')
+        self.assertEqual(ns_str.rjust(5, '*'), '**123')
+
+    def test_nsstring_rpartition(self):
+        ns_str = ns_from_py('hello new world')
+        self.assertEqual(ns_str.rpartition(' '), ('hello new', ' ', 'world'))
+        self.assertEqual(ns_str.rpartition('l'), ('hello new wor', 'l', 'd'))
+
+    def test_nsstring_rsplit(self):
+        ns_str = ns_from_py('hello new world')
+        self.assertEqual(ns_str.rsplit(), ['hello', 'new', 'world'])
+        self.assertEqual(ns_str.rsplit(' ', 1), ['hello new', 'world'])
+        self.assertEqual(ns_str.rsplit('l'), ['he', '', 'o new wor', 'd'])
+        self.assertEqual(ns_str.rsplit('l', 2), ['hel', 'o new wor', 'd'])
+
+    def test_nsstring_rstrip(self):
+        ns_str = ns_from_py('   hello   ')
+        self.assertEqual(ns_str.rstrip(), '   hello')
+
+        ns_str = ns_from_py('...hello...')
+        self.assertEqual(ns_str.rstrip('.'), '...hello')
+
+    def test_nsstring_split(self):
+        ns_str = ns_from_py('hello new world')
+        self.assertEqual(ns_str.split(), ['hello', 'new', 'world'])
+        self.assertEqual(ns_str.split(' ', 1), ['hello', 'new world'])
+        self.assertEqual(ns_str.split('l'), ['he', '', 'o new wor', 'd'])
+        self.assertEqual(ns_str.split('l', 2), ['he', '', 'o new world'])
+
+    def test_nsstring_splitlines(self):
+        ns_str = ns_from_py('Hello\nnew\nworld\n')
+        self.assertEqual(ns_str.splitlines(), ['Hello', 'new', 'world'])
+
+    def test_nsstring_strip(self):
+        ns_str = ns_from_py('   hello   ')
+        self.assertEqual(ns_str.strip(), 'hello')
+
+        ns_str = ns_from_py('...hello...')
+        self.assertEqual(ns_str.strip('.'), 'hello')
+
+    def test_nsstring_swapcase(self):
+        ns_str = ns_from_py('lower, UPPER & Mixed!')
+        self.assertEqual(ns_str.swapcase(), 'LOWER, upper & mIXED!')
+
+    def test_nsstring_title(self):
+        ns_str = ns_from_py('lower, UPPER & Mixed!')
+        self.assertEqual(ns_str.title(), 'Lower, Upper & Mixed!')
+
+    def test_nsstring_translate(self):
+        ns_str = ns_from_py('hello')
+        self.assertEqual(ns_str.translate({108: 'g', 111: '!!'}), 'hegg!!')
+
+    def test_nsstring_upper(self):
+        ns_str = ns_from_py('lower, UPPER & Mixed!')
+        self.assertEqual(ns_str.upper(), 'LOWER, UPPER & MIXED!')
+
+    def test_nsstring_zfill(self):
+        ns_str = ns_from_py('123')
+        self.assertEqual(ns_str.zfill(5), '00123')

--- a/tests/test_NSString.py
+++ b/tests/test_NSString.py
@@ -220,8 +220,14 @@ class NSStringTests(unittest.TestCase):
 
     def test_nsstring_encode(self):
         ns_str = ns_from_py('Uñîçö∂€ string')
-        self.assertEqual(ns_str.encode('utf-8'), b'U\xc3\xb1\xc3\xae\xc3\xa7\xc3\xb6\xe2\x88\x82\xe2\x82\xac string')
-        self.assertEqual(ns_str.encode('utf-16'), b'\xff\xfeU\x00\xf1\x00\xee\x00\xe7\x00\xf6\x00\x02"\xac  \x00s\x00t\x00r\x00i\x00n\x00g\x00')
+        self.assertEqual(
+            ns_str.encode('utf-8'),
+            b'U\xc3\xb1\xc3\xae\xc3\xa7\xc3\xb6\xe2\x88\x82\xe2\x82\xac string'
+        )
+        self.assertEqual(
+            ns_str.encode('utf-16'),
+            b'\xff\xfeU\x00\xf1\x00\xee\x00\xe7\x00\xf6\x00\x02"\xac  \x00s\x00t\x00r\x00i\x00n\x00g\x00'
+        )
 
         with self.assertRaises(UnicodeEncodeError):
             ns_str.encode('ascii')
@@ -267,7 +273,6 @@ class NSStringTests(unittest.TestCase):
         self.assertFalse(ns_from_py('abcd1234').isdigit())
 
     def test_nsstring_isidentifier(self):
-        ns_str = ns_from_py('')
         self.assertTrue(ns_from_py('def').isidentifier())
         self.assertTrue(ns_from_py('class').isidentifier())
         self.assertTrue(ns_from_py('hello').isidentifier())


### PR DESCRIPTION
This adds stubs for the remaining methods on `str` that aren't reflected on ObjCString. They all do conversions to Python strings and call the underlying methods, on the basis that if you're invoking the *Python* method, you're almost certainly in Python code, and therefore getting back a Python response makes sense.